### PR TITLE
feat: use user's local timezone for date formatting

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Manrope, Newsreader } from "next/font/google";
+import { TimezoneSync } from "@/components/timezone-sync";
 import "./globals.css";
 
 const manrope = Manrope({
@@ -37,6 +38,7 @@ export default function RootLayout({
       <body
         className={`${manrope.variable} ${newsreader.variable} ${ibmPlexMono.variable} bg-background text-foreground antialiased selection:bg-accent/20 selection:text-foreground`}
       >
+        <TimezoneSync />
         {children}
       </body>
     </html>

--- a/src/components/timezone-sync.tsx
+++ b/src/components/timezone-sync.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+const TZ_COOKIE = "tz";
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
+/**
+ * Sets the user's timezone cookie so server-rendered dates use local time.
+ * Runs once on mount; triggers a refresh when the cookie is first set.
+ */
+export function TimezoneSync() {
+  const router = useRouter();
+  const didSet = useRef(false);
+
+  useEffect(() => {
+    if (didSet.current) return;
+
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (!tz) return;
+
+    const existing = document.cookie
+      .split("; ")
+      .find((c) => c.startsWith(`${TZ_COOKIE}=`));
+    const alreadySet = existing?.split("=")[1] === tz;
+
+    if (!alreadySet) {
+      document.cookie = `${TZ_COOKIE}=${tz}; path=/; max-age=${ONE_YEAR_SECONDS}; SameSite=Lax`;
+      didSet.current = true;
+      router.refresh();
+    }
+  }, [router]);
+
+  return null;
+}

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,0 +1,55 @@
+import { cookies, headers } from "next/headers";
+
+const TZ_COOKIE = "tz";
+
+/**
+ * Get the user's timezone for server-side date formatting.
+ * Priority: tz cookie (set by client) > x-vercel-ip-timezone header (Vercel) > undefined.
+ */
+export async function getUserTimezone(): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  const tzCookie = cookieStore.get(TZ_COOKIE)?.value;
+  if (tzCookie) return tzCookie;
+
+  const headersList = await headers();
+  const vercelTz = headersList.get("x-vercel-ip-timezone");
+  if (vercelTz) return vercelTz;
+
+  return undefined;
+}
+
+type FormatDateOptions = {
+  month?: "numeric" | "2-digit" | "long" | "short" | "narrow";
+  day?: "numeric" | "2-digit";
+  hour?: "numeric" | "2-digit";
+  minute?: "numeric" | "2-digit";
+  year?: "numeric" | "2-digit";
+};
+
+/**
+ * Format a date in the user's local timezone when available.
+ * Falls back to runtime default (often UTC on server) when timezone is unknown.
+ */
+export async function formatDate(
+  date: Date,
+  options: FormatDateOptions = {},
+): Promise<string> {
+  const tz = await getUserTimezone();
+  return new Intl.DateTimeFormat("en-US", {
+    ...options,
+    ...(tz && { timeZone: tz }),
+  }).format(date);
+}
+
+/**
+ * Create an Intl.DateTimeFormat formatter with user's timezone for server use.
+ */
+export async function createDateFormatter(
+  options: Intl.DateTimeFormatOptions,
+): Promise<Intl.DateTimeFormat> {
+  const tz = await getUserTimezone();
+  return new Intl.DateTimeFormat("en-US", {
+    ...options,
+    ...(tz && { timeZone: tz }),
+  });
+}

--- a/src/lib/github-state.ts
+++ b/src/lib/github-state.ts
@@ -1,15 +1,7 @@
 import { hasGitHubAppEnv, hasDurableDatabaseUrl } from "@/lib/env";
 import { db } from "@/lib/db";
+import { formatDate } from "@/lib/format-date";
 import { getOptionalUserSession } from "@/lib/session";
-
-function formatDate(date: Date) {
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(date);
-}
 
 const reconnectAction = {
   label: "Reconnect GitHub",
@@ -113,12 +105,22 @@ export async function getGithubConnectionState() {
       },
       viewer: {
         login: session.account.login,
-        sessionExpiryLabel: formatDate(session.expiresAt),
+        sessionExpiryLabel: await formatDate(session.expiresAt, {
+          month: "short",
+          day: "numeric",
+          hour: "numeric",
+          minute: "2-digit",
+        }),
       },
       activitySync: latestActivitySync
         ? {
             status: latestActivitySync.status,
-            updatedAt: formatDate(latestActivitySync.updatedAt),
+            updatedAt: await formatDate(latestActivitySync.updatedAt, {
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit",
+            }),
           }
         : null,
       activitySyncRunning: latestActivitySync?.status === "running",

--- a/src/lib/live-metrics.ts
+++ b/src/lib/live-metrics.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { formatNumber } from "@/lib/dashboard";
 import type { AnalyticsView, MetricMode } from "@/lib/dashboard";
 import { hasDurableDatabaseUrl } from "@/lib/env";
+import { formatDate, getUserTimezone } from "@/lib/format-date";
 import { getOptionalUserSession } from "@/lib/session";
 
 type TimelineBucket = {
@@ -12,7 +13,11 @@ type TimelineBucket = {
   deletions: number;
 };
 
-function getViewConfig(view: AnalyticsView) {
+function getViewConfig(
+  view: AnalyticsView,
+  timeZone?: string,
+) {
+  const baseOpts = { ...(timeZone && { timeZone }) };
   if (view === "daily") {
     return {
       title: "Daily shipped work",
@@ -20,6 +25,7 @@ function getViewConfig(view: AnalyticsView) {
       stepDays: 1,
       filterLabel: "Last 14 days",
       formatter: new Intl.DateTimeFormat("en-US", {
+        ...baseOpts,
         month: "short",
         day: "numeric",
       }),
@@ -33,6 +39,7 @@ function getViewConfig(view: AnalyticsView) {
       stepDays: 7,
       filterLabel: "Last 12 weeks",
       formatter: new Intl.DateTimeFormat("en-US", {
+        ...baseOpts,
         month: "short",
         day: "numeric",
       }),
@@ -45,14 +52,15 @@ function getViewConfig(view: AnalyticsView) {
     stepDays: 30,
     filterLabel: "Last 12 months",
     formatter: new Intl.DateTimeFormat("en-US", {
+      ...baseOpts,
       month: "short",
       year: "2-digit",
     }),
   };
 }
 
-function buildTimelineBuckets(view: AnalyticsView) {
-  const config = getViewConfig(view);
+function buildTimelineBuckets(view: AnalyticsView, timeZone?: string) {
+  const config = getViewConfig(view, timeZone);
 
   if (view === "monthly") {
     const now = new Date();
@@ -102,8 +110,8 @@ function buildTimelineBuckets(view: AnalyticsView) {
   });
 }
 
-function getWindowStart(view: AnalyticsView) {
-  const firstBucket = buildTimelineBuckets(view)[0];
+function getWindowStart(view: AnalyticsView, timeZone?: string) {
+  const firstBucket = buildTimelineBuckets(view, timeZone)[0];
   return firstBucket?.start ?? new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
 }
 
@@ -153,13 +161,15 @@ export async function getLiveMetrics(view: AnalyticsView, mode: MetricMode) {
       })
     : null;
 
+  const timeZone = await getUserTimezone();
+
   if (installationIds.length === 0) {
     return {
       profile: {
         login: `@${session.account.login}`,
         source: "live" as const,
       },
-    filters: [getViewConfig(view).filterLabel, "Shipped work"],
+    filters: [getViewConfig(view, timeZone).filterLabel, "Shipped work"],
       summary: [
         {
           label: "Lines shipped",
@@ -182,7 +192,7 @@ export async function getLiveMetrics(view: AnalyticsView, mode: MetricMode) {
           detail: "Run the shipped-work sync once the installation is connected.",
         },
       ],
-      timeline: buildTimelineBuckets(view).map((bucket) => ({
+      timeline: buildTimelineBuckets(view, timeZone).map((bucket) => ({
         label: bucket.label,
         additions: 0,
         deletions: 0,
@@ -190,11 +200,11 @@ export async function getLiveMetrics(view: AnalyticsView, mode: MetricMode) {
         deletionsHeight: 0,
       })),
       repositories: [],
-      chartTitle: getViewConfig(view).title,
+      chartTitle: getViewConfig(view, timeZone).title,
     };
   }
 
-  const windowStart = getWindowStart(view);
+  const windowStart = getWindowStart(view, timeZone);
   const dailyStats = await db.dailyUserRepoStats.findMany({
     where: {
       accountId: session.accountId,
@@ -215,7 +225,7 @@ export async function getLiveMetrics(view: AnalyticsView, mode: MetricMode) {
     },
   });
 
-  const timeline = buildTimelineBuckets(view);
+  const timeline = buildTimelineBuckets(view, timeZone);
   const installationRepoCount = await db.repository.count({
     where: {
       installationId: {
@@ -304,7 +314,7 @@ export async function getLiveMetrics(view: AnalyticsView, mode: MetricMode) {
       source: "live" as const,
     },
     filters: [
-      getViewConfig(view).filterLabel,
+      getViewConfig(view, timeZone).filterLabel,
       mode === "shipped" ? "Shipped work" : "Shipped work",
       "Merged PRs only",
       `${installationRepoCount} tracked repos`,
@@ -329,12 +339,15 @@ export async function getLiveMetrics(view: AnalyticsView, mode: MetricMode) {
         label: "Latest sync",
         value: runningActivitySync ? "Running" : "Ready",
         detail: (runningActivitySync ?? latestActivitySync)?.updatedAt
-          ? `Updated ${new Intl.DateTimeFormat("en-US", {
-              month: "short",
-              day: "numeric",
-              hour: "numeric",
-              minute: "2-digit",
-            }).format((runningActivitySync ?? latestActivitySync)!.updatedAt)}`
+          ? `Updated ${await formatDate(
+              (runningActivitySync ?? latestActivitySync)!.updatedAt,
+              {
+                month: "short",
+                day: "numeric",
+                hour: "numeric",
+                minute: "2-digit",
+              },
+            )}`
           : "Run your first shipped-work sync to replace sample metrics.",
       },
     ],
@@ -352,7 +365,7 @@ export async function getLiveMetrics(view: AnalyticsView, mode: MetricMode) {
         ...repository,
         detail: `${formatNumber(repository.mergedPrCount)} merged PRs in the selected window.`,
       })),
-    chartTitle: getViewConfig(view).title,
+    chartTitle: getViewConfig(view, timeZone).title,
     latestPullRequestTitle: latestPullRequest
       ? `${latestPullRequest.repository.owner}/${latestPullRequest.repository.name}: ${latestPullRequest.title}`
       : null,


### PR DESCRIPTION
Formats all displayed dates (session expiry, sync timestamps, chart labels, invite expiry) in the user's local timezone instead of server default.

## Changes
- **src/lib/format-date.ts**: New utility that reads user timezone from `tz` cookie (set by client) or `x-vercel-ip-timezone` header (Vercel)
- **src/components/timezone-sync.tsx**: Client component that sets the `tz` cookie on mount and triggers a refresh so server-rendered dates pick it up
- **src/lib/github-state.ts**: Uses `formatDate()` for session expiry and activity sync timestamps
- **src/lib/live-metrics.ts**: Passes user timezone to chart formatters and "Updated" timestamp
- **src/app/layout.tsx**: Adds TimezoneSync to root layout

Client components (social-shell, social-invite-card) already use local time since `Intl.DateTimeFormat` without `timeZone` defaults to the browser's local timezone.