### PR TITLE
feat: leaderboard opted in by default, add MVP-critical social API tests

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,7 +50,7 @@ model GitHubAccount {
   avatarUrl                   String?
   bio                         String?
   profileVisibility           ProfileVisibility     @default(PRIVATE)
-  leaderboardVisibility       LeaderboardVisibility @default(HIDDEN)
+  leaderboardVisibility       LeaderboardVisibility @default(PUBLIC)
   socialOnboardingCompletedAt DateTime?
   createdAt                   DateTime              @default(now())
   updatedAt                   DateTime              @updatedAt

--- a/src/app/api/social/friends/invite/route.test.ts
+++ b/src/app/api/social/friends/invite/route.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getRequiredSocialSessionMock, createFriendInviteMock } = vi.hoisted(() => ({
+  getRequiredSocialSessionMock: vi.fn(),
+  createFriendInviteMock: vi.fn(),
+}));
+
+vi.mock("@/lib/social", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/social")>();
+  return {
+    ...actual,
+    getRequiredSocialSession: getRequiredSocialSessionMock,
+    createFriendInvite: createFriendInviteMock,
+  };
+});
+
+import { POST } from "@/app/api/social/friends/invite/route";
+
+describe("POST /api/social/friends/invite", () => {
+  beforeEach(() => {
+    getRequiredSocialSessionMock.mockReset();
+    createFriendInviteMock.mockReset();
+  });
+
+  it("returns 401 when there is no social session", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue(null);
+
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    expect(createFriendInviteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns invite payload for authenticated user", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+    createFriendInviteMock.mockResolvedValue({
+      token: "abc123",
+      invitePath: "/social/invite/abc123",
+      expiresAt: "2025-03-20T00:00:00.000Z",
+    });
+
+    const response = await POST();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      token: "abc123",
+      invitePath: "/social/invite/abc123",
+      expiresAt: "2025-03-20T00:00:00.000Z",
+    });
+    expect(createFriendInviteMock).toHaveBeenCalledWith("account-1");
+  });
+});

--- a/src/app/api/social/friends/respond/route.test.ts
+++ b/src/app/api/social/friends/respond/route.test.ts
@@ -1,0 +1,113 @@
+import { NextRequest } from "next/server";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getRequiredSocialSessionMock,
+  respondToFriendInviteMock,
+} = vi.hoisted(() => ({
+  getRequiredSocialSessionMock: vi.fn(),
+  respondToFriendInviteMock: vi.fn(),
+}));
+
+vi.mock("@/lib/social", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/social")>();
+  return {
+    ...actual,
+    getRequiredSocialSession: getRequiredSocialSessionMock,
+    respondToFriendInvite: respondToFriendInviteMock,
+  };
+});
+
+import { POST } from "@/app/api/social/friends/respond/route";
+
+describe("POST /api/social/friends/respond", () => {
+  beforeEach(() => {
+    getRequiredSocialSessionMock.mockReset();
+    respondToFriendInviteMock.mockReset();
+  });
+
+  it("returns 401 when there is no social session", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue(null);
+
+    const request = new NextRequest("http://localhost/api/social/friends/respond", {
+      method: "POST",
+      body: JSON.stringify({ token: "validtoken123", action: "accept" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    expect(respondToFriendInviteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when payload is invalid", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+
+    const request = new NextRequest("http://localhost/api/social/friends/respond", {
+      method: "POST",
+      body: JSON.stringify({ token: "short", action: "accept" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(respondToFriendInviteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when action is invalid", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+
+    const request = new NextRequest("http://localhost/api/social/friends/respond", {
+      method: "POST",
+      body: JSON.stringify({ token: "validtoken123", action: "invalid" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(respondToFriendInviteMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts invite and returns status for valid request", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-2" });
+    respondToFriendInviteMock.mockResolvedValue({
+      status: "accepted",
+      inviterLogin: "inviter",
+    });
+
+    const request = new NextRequest("http://localhost/api/social/friends/respond", {
+      method: "POST",
+      body: JSON.stringify({ token: "validtoken123", action: "accept" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "accepted",
+      inviterLogin: "inviter",
+    });
+    expect(respondToFriendInviteMock).toHaveBeenCalledWith(
+      "account-2",
+      "validtoken123",
+      "accept",
+    );
+  });
+
+  it("returns 400 when respondToFriendInvite throws", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-2" });
+    respondToFriendInviteMock.mockRejectedValue(new Error("Invite has expired"));
+
+    const request = new NextRequest("http://localhost/api/social/friends/respond", {
+      method: "POST",
+      body: JSON.stringify({ token: "expiredtoken", action: "accept" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe("Invite has expired");
+  });
+});

--- a/src/app/api/social/friends/route.test.ts
+++ b/src/app/api/social/friends/route.test.ts
@@ -1,0 +1,92 @@
+import { NextRequest } from "next/server";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getRequiredSocialSessionMock,
+  getSocialFriendsMock,
+} = vi.hoisted(() => ({
+  getRequiredSocialSessionMock: vi.fn(),
+  getSocialFriendsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/social", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/social")>();
+  return {
+    ...actual,
+    getRequiredSocialSession: getRequiredSocialSessionMock,
+    getSocialFriends: getSocialFriendsMock,
+  };
+});
+
+import { GET } from "@/app/api/social/friends/route";
+
+describe("GET /api/social/friends", () => {
+  beforeEach(() => {
+    getRequiredSocialSessionMock.mockReset();
+    getSocialFriendsMock.mockReset();
+  });
+
+  it("returns 401 when there is no social session", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue(null);
+
+    const request = new NextRequest("http://localhost/api/social/friends");
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(getSocialFriendsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns friends payload with default window", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+    getSocialFriendsMock.mockResolvedValue({
+      window: "30d",
+      friends: [],
+      pendingInvites: [],
+    });
+
+    const request = new NextRequest("http://localhost/api/social/friends");
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      window: "30d",
+      friends: [],
+      pendingInvites: [],
+    });
+    expect(getSocialFriendsMock).toHaveBeenCalledWith("account-1", "30d");
+  });
+
+  it("passes window from query params", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+    getSocialFriendsMock.mockResolvedValue({
+      window: "7d",
+      friends: [{ login: "friend1", rank: 1 }],
+      pendingInvites: [],
+    });
+
+    const request = new NextRequest(
+      "http://localhost/api/social/friends?window=7d",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(getSocialFriendsMock).toHaveBeenCalledWith("account-1", "7d");
+  });
+
+  it("returns 400 when window is invalid", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+
+    const request = new NextRequest(
+      "http://localhost/api/social/friends?window=invalid",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+    expect(getSocialFriendsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/social/leaderboard/route.test.ts
+++ b/src/app/api/social/leaderboard/route.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from "next/server";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getRequiredSocialSessionMock,
+  getSocialLeaderboardMock,
+} = vi.hoisted(() => ({
+  getRequiredSocialSessionMock: vi.fn(),
+  getSocialLeaderboardMock: vi.fn(),
+}));
+
+vi.mock("@/lib/social", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/social")>();
+  return {
+    ...actual,
+    getRequiredSocialSession: getRequiredSocialSessionMock,
+    getSocialLeaderboard: getSocialLeaderboardMock,
+  };
+});
+
+import { GET } from "@/app/api/social/leaderboard/route";
+
+describe("GET /api/social/leaderboard", () => {
+  beforeEach(() => {
+    getRequiredSocialSessionMock.mockReset();
+    getSocialLeaderboardMock.mockReset();
+  });
+
+  it("returns 401 when there is no social session", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue(null);
+
+    const request = new NextRequest("http://localhost/api/social/leaderboard");
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(getSocialLeaderboardMock).not.toHaveBeenCalled();
+  });
+
+  it("returns leaderboard with default scope and window", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+    getSocialLeaderboardMock.mockResolvedValue({
+      scope: "friends",
+      window: "30d",
+      entries: [{ rank: 1, login: "user1", vibeScore: 100 }],
+    });
+
+    const request = new NextRequest("http://localhost/api/social/leaderboard");
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      scope: "friends",
+      window: "30d",
+      entries: [{ rank: 1, login: "user1", vibeScore: 100 }],
+    });
+    expect(getSocialLeaderboardMock).toHaveBeenCalledWith(
+      "account-1",
+      "friends",
+      "30d",
+    );
+  });
+
+  it("passes scope and window from query params", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+    getSocialLeaderboardMock.mockResolvedValue({
+      scope: "global",
+      window: "7d",
+      entries: [],
+    });
+
+    const request = new NextRequest(
+      "http://localhost/api/social/leaderboard?scope=global&window=7d",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(getSocialLeaderboardMock).toHaveBeenCalledWith(
+      "account-1",
+      "global",
+      "7d",
+    );
+  });
+
+  it("returns 400 when query params are invalid", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+
+    const request = new NextRequest(
+      "http://localhost/api/social/leaderboard?scope=invalid&window=90d",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+    expect(getSocialLeaderboardMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/social/profile/route.test.ts
+++ b/src/app/api/social/profile/route.test.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from "next/server";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getRequiredSocialSessionMock, updateSocialProfileMock } = vi.hoisted(() => ({
+  getRequiredSocialSessionMock: vi.fn(),
+  updateSocialProfileMock: vi.fn(),
+}));
+
+vi.mock("@/lib/social", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/social")>();
+  return {
+    ...actual,
+    getRequiredSocialSession: getRequiredSocialSessionMock,
+    updateSocialProfile: updateSocialProfileMock,
+  };
+});
+
+import { PATCH } from "@/app/api/social/profile/route";
+
+describe("PATCH /api/social/profile", () => {
+  beforeEach(() => {
+    getRequiredSocialSessionMock.mockReset();
+    updateSocialProfileMock.mockReset();
+  });
+
+  it("returns 401 when there is no social session", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue(null);
+
+    const request = new NextRequest("http://localhost/api/social/profile", {
+      method: "PATCH",
+      body: JSON.stringify({
+        bio: "Hello",
+        profileVisibility: "PUBLIC",
+        leaderboardVisibility: "PUBLIC",
+      }),
+    });
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(401);
+    expect(updateSocialProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when payload is invalid", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+
+    const request = new NextRequest("http://localhost/api/social/profile", {
+      method: "PATCH",
+      body: JSON.stringify({ profileVisibility: "INVALID" }),
+    });
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(400);
+    expect(updateSocialProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+
+    const request = new NextRequest("http://localhost/api/social/profile", {
+      method: "PATCH",
+      body: "not json",
+    });
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(400);
+    expect(updateSocialProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("updates profile and returns social payload for valid request", async () => {
+    getRequiredSocialSessionMock.mockResolvedValue({ accountId: "account-1" });
+    const validData = {
+      bio: "Builder",
+      profileVisibility: "PUBLIC" as const,
+      leaderboardVisibility: "HIDDEN" as const,
+    };
+    updateSocialProfileMock.mockResolvedValue({
+      profile: { login: "octocat" },
+      settings: { leaderboardVisibility: "HIDDEN" },
+    });
+
+    const request = new NextRequest("http://localhost/api/social/profile", {
+      method: "PATCH",
+      body: JSON.stringify(validData),
+    });
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      profile: { login: "octocat" },
+      settings: { leaderboardVisibility: "HIDDEN" },
+    });
+    expect(updateSocialProfileMock).toHaveBeenCalledWith("account-1", validData);
+  });
+});

--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -30,8 +30,8 @@ export default async function SocialPage({ searchParams }: SocialPageProps) {
                 <h1 className="page-title">Connect GitHub before you compare.</h1>
                 <p className="page-description">
                   Social features run on the same synced GitHub activity as your
-                  personal dashboard. Sign in first, then invite friends or opt
-                  into the public leaderboard.
+                  personal dashboard. Sign in first—you&apos;re on the public
+                  leaderboard by default, opt out anytime in Profile.
                 </p>
               </div>
               <div className="hero-actions">

--- a/src/components/social-shell.tsx
+++ b/src/components/social-shell.tsx
@@ -228,8 +228,8 @@ export function SocialShell({
           <div className="space-y-3">
             <h1 className="page-title">Bring your crew into the vibe.</h1>
             <p className="page-description">
-              Compare shipped-output momentum with friends, or opt into the
-              public leaderboard when you want the wider room to see it.
+              Compare shipped-output momentum with friends. You&apos;re on the
+              public leaderboard by default—opt out anytime from Profile.
             </p>
           </div>
           <div className="hero-actions">

--- a/src/lib/social.ts
+++ b/src/lib/social.ts
@@ -374,7 +374,6 @@ export async function refreshGlobalLeaderboardSnapshots(window?: SocialWindow) {
   for (const currentWindow of windows) {
     const eligibleAccounts = await db.gitHubAccount.findMany({
       where: {
-        profileVisibility: ProfileVisibility.PUBLIC,
         leaderboardVisibility: LeaderboardVisibility.PUBLIC,
       },
       select: {
@@ -496,7 +495,6 @@ export async function getSocialMe(accountId: string) {
     ranks: {
       friends: friendRank,
       global:
-        identity.profileVisibility === ProfileVisibility.PUBLIC &&
         identity.leaderboardVisibility === LeaderboardVisibility.PUBLIC
           ? globalRank
           : null,


### PR DESCRIPTION
## Summary
- **Leaderboard default**: New accounts are now opted into the public leaderboard by default. Users can opt out via Profile → Leaderboard visibility.
- **Leaderboard eligibility**: Relaxed from requiring both profile + leaderboard visibility to only leaderboard visibility.
- **UI copy**: Updated to reflect the new default and opt-out path.
- **Tests**: Added tests for social APIs before MVP launch.

## Changes
- `prisma/schema.prisma`: `leaderboardVisibility` default HIDDEN → PUBLIC
- `src/lib/social.ts`: Global leaderboard eligibility uses only `leaderboardVisibility`; `getSocialMe` global rank display aligned
- `src/components/social-shell.tsx`, `src/app/social/page.tsx`: Copy updated
- New tests: PATCH profile, POST friends/invite, POST friends/respond, GET friends, GET leaderboard

## Tests
`npm test` — 33 tests pass