### PR TITLE
fix: validate timezone before Intl use to prevent server crash

### DIFF
--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -3,17 +3,31 @@ import { cookies, headers } from "next/headers";
 const TZ_COOKIE = "tz";
 
 /**
+ * Validate that a timezone string is supported by Intl.
+ * Vercel's x-vercel-ip-timezone or edge cases can return invalid values
+ * that cause RangeError and crash the server.
+ */
+function isSupportedTimezone(tz: string): boolean {
+  try {
+    Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Get the user's timezone for server-side date formatting.
  * Priority: tz cookie (set by client) > x-vercel-ip-timezone header (Vercel) > undefined.
  */
 export async function getUserTimezone(): Promise<string | undefined> {
   const cookieStore = await cookies();
   const tzCookie = cookieStore.get(TZ_COOKIE)?.value;
-  if (tzCookie) return tzCookie;
+  if (tzCookie && isSupportedTimezone(tzCookie)) return tzCookie;
 
   const headersList = await headers();
   const vercelTz = headersList.get("x-vercel-ip-timezone");
-  if (vercelTz) return vercelTz;
+  if (vercelTz && isSupportedTimezone(vercelTz)) return vercelTz;
 
   return undefined;
 }


### PR DESCRIPTION
## Root cause

The user-local-timezone feature (merged via PR #45 on Mar 13) introduced `formatDate()` and `getUserTimezone()` which read the timezone from:
1. `tz` cookie (client-set)
2. Vercel's `x-vercel-ip-timezone` header

When either returns an **invalid or unsupported IANA timezone string**, `Intl.DateTimeFormat('en-US', { timeZone: tz })` throws `RangeError`, causing "Application error: a server-side exception has occurred" on Vercel.

This can happen when:
- Vercel's geo-IP lookup returns an edge-case or deprecated timezone
- The header is malformed in certain request contexts

## Fix

Added `isSupportedTimezone()` that validates the timezone by attempting to create an `Intl.DateTimeFormat` with it. Only return the timezone from `getUserTimezone()` if validation succeeds; otherwise fall back to `undefined` (server default, often UTC).

## Verification

- All existing tests pass
- Invalid timezones confirmed to throw RangeError locally