### PR TITLE
fix: add try/catch around Intl usage to prevent crash after GitHub login

### DIFF
--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -43,27 +43,38 @@ type FormatDateOptions = {
 /**
  * Format a date in the user's local timezone when available.
  * Falls back to runtime default (often UTC on server) when timezone is unknown.
+ * Wraps Intl usage in try/catch so any RangeError (e.g. invalid tz edge cases)
+ * does not crash the server.
  */
 export async function formatDate(
   date: Date,
   options: FormatDateOptions = {},
 ): Promise<string> {
-  const tz = await getUserTimezone();
-  return new Intl.DateTimeFormat("en-US", {
-    ...options,
-    ...(tz && { timeZone: tz }),
-  }).format(date);
+  try {
+    const tz = await getUserTimezone();
+    return new Intl.DateTimeFormat("en-US", {
+      ...options,
+      ...(tz && { timeZone: tz }),
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat("en-US", options).format(date);
+  }
 }
 
 /**
  * Create an Intl.DateTimeFormat formatter with user's timezone for server use.
+ * Falls back to formatter without timezone if Intl throws (e.g. invalid tz).
  */
 export async function createDateFormatter(
   options: Intl.DateTimeFormatOptions,
 ): Promise<Intl.DateTimeFormat> {
-  const tz = await getUserTimezone();
-  return new Intl.DateTimeFormat("en-US", {
-    ...options,
-    ...(tz && { timeZone: tz }),
-  });
+  try {
+    const tz = await getUserTimezone();
+    return new Intl.DateTimeFormat("en-US", {
+      ...options,
+      ...(tz && { timeZone: tz }),
+    });
+  } catch {
+    return new Intl.DateTimeFormat("en-US", options);
+  }
 }

--- a/src/lib/live-metrics.ts
+++ b/src/lib/live-metrics.ts
@@ -13,6 +13,17 @@ type TimelineBucket = {
   deletions: number;
 };
 
+function createFormatter(
+  opts: Intl.DateTimeFormatOptions,
+  withTimezone: Record<string, unknown>,
+): Intl.DateTimeFormat {
+  try {
+    return new Intl.DateTimeFormat("en-US", { ...opts, ...withTimezone });
+  } catch {
+    return new Intl.DateTimeFormat("en-US", opts);
+  }
+}
+
 function getViewConfig(
   view: AnalyticsView,
   timeZone?: string,
@@ -24,11 +35,10 @@ function getViewConfig(
       bucketCount: 14,
       stepDays: 1,
       filterLabel: "Last 14 days",
-      formatter: new Intl.DateTimeFormat("en-US", {
-        ...baseOpts,
-        month: "short",
-        day: "numeric",
-      }),
+      formatter: createFormatter(
+        { month: "short", day: "numeric" },
+        baseOpts,
+      ),
     };
   }
 
@@ -38,11 +48,10 @@ function getViewConfig(
       bucketCount: 12,
       stepDays: 7,
       filterLabel: "Last 12 weeks",
-      formatter: new Intl.DateTimeFormat("en-US", {
-        ...baseOpts,
-        month: "short",
-        day: "numeric",
-      }),
+      formatter: createFormatter(
+        { month: "short", day: "numeric" },
+        baseOpts,
+      ),
     };
   }
 
@@ -51,11 +60,10 @@ function getViewConfig(
     bucketCount: 12,
     stepDays: 30,
     filterLabel: "Last 12 months",
-    formatter: new Intl.DateTimeFormat("en-US", {
-      ...baseOpts,
-      month: "short",
-      year: "2-digit",
-    }),
+    formatter: createFormatter(
+      { month: "short", year: "2-digit" },
+      baseOpts,
+    ),
   };
 }
 


### PR DESCRIPTION
Closes the connected-user crash when landing on /?github=connected after OAuth.

- formatDate and createDateFormatter: wrap Intl usage in try/catch, fall back to no-timezone on throw
- live-metrics getViewConfig: wrap formatter creation in try/catch via createFormatter helper

Defense in depth alongside existing isSupportedTimezone validation. Any Intl edge case (invalid tz, locale quirks, etc.) no longer crashes the server.