### PR TITLE
fix: resolve UI issues — dark mode, mobile chart, polling, font cleanup

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 :root {
+  color-scheme: light dark;
   --background: #f5efe6;
   --foreground: #1f2733;
   --panel: rgba(255, 251, 246, 0.94);
@@ -28,7 +29,7 @@
   --color-accent: var(--accent);
   --color-danger: var(--danger);
   --font-sans: var(--font-manrope);
-  --font-mono: var(--font-ibm-plex-mono);
+  --font-mono: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Menlo, Consolas, monospace;
 }
 
 * {
@@ -616,5 +617,169 @@ a {
   .scope-item-head {
     flex-direction: column;
     align-items: stretch;
+  }
+}
+
+/* ============================================================
+   DARK MODE — all overrides in one block
+   ============================================================ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #1a1714;
+    --foreground: #e8e0d5;
+    --panel: rgba(30, 26, 22, 0.94);
+    --panel-strong: rgba(36, 31, 26, 0.98);
+    --panel-soft: rgba(40, 34, 28, 0.90);
+    --muted: #8c8078;
+    --line: rgba(200, 185, 165, 0.12);
+    --line-strong: rgba(200, 185, 165, 0.20);
+    --accent: #8fa3c8;
+    --accent-strong: #7d94ba;
+    --accent-2: #c89a6a;
+    --danger: #c47c78;
+    --warning: #c89a5e;
+    --success: #7aa888;
+    --button-primary-fg: #f0e8de;
+    --button-secondary-bg: rgba(44, 38, 32, 0.92);
+  }
+
+  body {
+    background:
+      radial-gradient(circle at top left, rgba(60, 50, 40, 0.6), transparent 34%),
+      radial-gradient(circle at bottom right, rgba(160, 100, 50, 0.10), transparent 30%),
+      linear-gradient(180deg, #1a1714 0%, #15120f 100%);
+  }
+
+  .page-wash {
+    background:
+      radial-gradient(circle at 8% 12%, rgba(60, 50, 40, 0.40), transparent 26%),
+      radial-gradient(circle at 92% 18%, rgba(110, 132, 173, 0.08), transparent 24%),
+      radial-gradient(circle at 72% 92%, rgba(160, 100, 50, 0.08), transparent 26%);
+  }
+
+  .top-panel,
+  .dashboard-shell,
+  .story-panel,
+  .sidebar-panel,
+  .metric-card,
+  .onboarding-card,
+  .status-note {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      0 18px 48px rgba(0, 0, 0, 0.30);
+  }
+
+  .top-panel-meta {
+    background: rgba(26, 22, 18, 0.84);
+  }
+
+  .meta-row {
+    border-bottom-color: rgba(200, 185, 165, 0.10);
+  }
+
+  .eyebrow-subtle {
+    border-color: rgba(200, 185, 165, 0.14);
+    background: rgba(36, 31, 26, 0.5);
+  }
+
+  .dashboard-pill,
+  .filter-chip,
+  .repo-visibility,
+  .repo-rank,
+  .legend-pill {
+    border-color: rgba(200, 185, 165, 0.12);
+    background: rgba(26, 22, 18, 0.90);
+  }
+
+  .bar-chart-shell {
+    border-color: rgba(200, 185, 165, 0.10);
+    background:
+      linear-gradient(to top, rgba(110, 132, 173, 0.08) 1px, transparent 1px),
+      linear-gradient(180deg, rgba(30, 26, 22, 0.92), rgba(24, 20, 16, 0.92));
+  }
+
+  .bar-chart-shell line {
+    stroke: rgba(200, 185, 165, 0.14);
+  }
+
+  .bar-chart-shell text {
+    fill: rgba(180, 165, 145, 0.85);
+  }
+
+  .chart-stat-card {
+    background: rgba(26, 22, 18, 0.72);
+  }
+
+  .repo-card,
+  .scope-item {
+    border-color: rgba(200, 185, 165, 0.10);
+    background: rgba(26, 22, 18, 0.72);
+  }
+
+  .repo-meter {
+    background: rgba(200, 185, 165, 0.10);
+  }
+
+  .sidebar-panel {
+    background: linear-gradient(180deg, rgba(34, 29, 24, 0.98), rgba(28, 23, 18, 0.94));
+  }
+
+  .status-note-active {
+    border-color: rgba(110, 132, 173, 0.22);
+    background: linear-gradient(180deg, rgba(110, 132, 173, 0.16), rgba(30, 26, 22, 0.92));
+  }
+
+  .status-note-success {
+    border-color: rgba(102, 143, 115, 0.24);
+    background: linear-gradient(180deg, rgba(102, 143, 115, 0.14), rgba(30, 26, 22, 0.92));
+  }
+
+  .status-note-danger {
+    border-color: rgba(186, 108, 103, 0.22);
+    background: linear-gradient(180deg, rgba(186, 108, 103, 0.14), rgba(30, 26, 22, 0.92));
+  }
+
+  .button-secondary:hover {
+    border-color: rgba(143, 163, 200, 0.22);
+    background: rgba(52, 44, 36, 0.98);
+  }
+
+  .toggle-pill {
+    border-color: rgba(200, 185, 165, 0.12);
+    background: rgba(36, 31, 26, 0.54);
+  }
+
+  /* Must come after .toggle-pill override to win on specificity tie */
+  .toggle-pill-active {
+    border-color: rgba(143, 163, 200, 0.30);
+    background: rgba(143, 163, 200, 0.18);
+    color: var(--accent-strong);
+    box-shadow: inset 0 0 0 1px rgba(143, 163, 200, 0.10);
+  }
+
+  .eyebrow {
+    border-color: rgba(143, 163, 200, 0.22);
+    background: rgba(143, 163, 200, 0.12);
+  }
+
+  .button-primary:focus-visible,
+  .button-secondary:focus-visible,
+  .toggle-pill:focus-visible {
+    box-shadow:
+      0 0 0 3px rgba(26, 22, 18, 0.96),
+      0 0 0 5px rgba(143, 163, 200, 0.40);
+  }
+
+  /* Tailwind white utility overrides — covers social-shell.tsx and page.tsx card surfaces */
+  .bg-white\/70 {
+    background-color: rgba(30, 26, 22, 0.70) !important;
+  }
+
+  .bg-white\/65 {
+    background-color: rgba(30, 26, 22, 0.65) !important;
+  }
+
+  .bg-white {
+    background-color: #1e1a16 !important;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { IBM_Plex_Mono, Manrope, Newsreader } from "next/font/google";
+import { Manrope, Newsreader } from "next/font/google";
 import { TimezoneSync } from "@/components/timezone-sync";
 import "./globals.css";
 
@@ -15,12 +15,6 @@ const newsreader = Newsreader({
   display: "swap",
 });
 
-const ibmPlexMono = IBM_Plex_Mono({
-  variable: "--font-ibm-plex-mono",
-  subsets: ["latin"],
-  weight: ["400", "500", "600"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "Vibe Tracker",
@@ -34,9 +28,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" style={{ colorScheme: "light" }}>
+    <html lang="en">
       <body
-        className={`${manrope.variable} ${newsreader.variable} ${ibmPlexMono.variable} bg-background text-foreground antialiased selection:bg-accent/20 selection:text-foreground`}
+        className={`${manrope.variable} ${newsreader.variable} bg-background text-foreground antialiased selection:bg-accent/20 selection:text-foreground`}
       >
         <TimezoneSync />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -163,18 +163,6 @@ function getTickValues(maxValue: number) {
   return [roundedMax, Math.round(roundedMax * 0.66), Math.round(roundedMax * 0.33), 0];
 }
 
-function shouldShowXAxisLabel(index: number, total: number, view: AnalyticsView) {
-  if (index === 0 || index === total - 1) {
-    return true;
-  }
-
-  if (view === "monthly") {
-    return true;
-  }
-
-  return index % 2 === 0;
-}
-
 function buildBarChartGeometry(timeline: TimelinePoint[]) {
   const innerWidth = CHART_WIDTH - CHART_PADDING.left - CHART_PADDING.right;
   const innerHeight = CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom;
@@ -228,6 +216,172 @@ function buildBarChartGeometry(timeline: TimelinePoint[]) {
     maxValue,
     innerHeight,
   };
+}
+
+function DashboardMetrics({
+  summary,
+}: {
+  summary: Array<{ label: string; value: string; detail: string }>;
+}) {
+  return (
+    <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {summary.map((item) => (
+        <article key={item.label} className="metric-card">
+          <p className="metric-label">{item.label}</p>
+          <p className="metric-value">{item.value}</p>
+          <p className="metric-detail">{item.detail}</p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+type GithubStateInstallation = {
+  id: string;
+  githubInstallId: number;
+  accountLogin: string;
+  repositoryCount: number;
+  repositoryNames: string[];
+};
+
+type RepoSummary = {
+  name: string;
+  detail: string;
+  visibility: string;
+  additions: number;
+  deletions: number;
+  commitCount: number;
+};
+
+function RepoSection({
+  repositories,
+  repoActivityMax,
+  installations,
+  connected,
+  hasInstallations,
+  accessibleRepositoryCount,
+}: {
+  repositories: RepoSummary[];
+  repoActivityMax: number;
+  installations: GithubStateInstallation[];
+  connected: boolean;
+  hasInstallations: boolean;
+  accessibleRepositoryCount: number;
+}) {
+  return (
+    <section className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_360px]">
+      <section className="story-panel">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="panel-label">Repository pressure</p>
+            <h3 className="panel-heading">Where the work landed</h3>
+          </div>
+          <span className="dashboard-pill">{repositories.length} repos</span>
+        </div>
+
+        <div className="repo-list">
+          {repositories.length > 0 ? (
+            repositories.map((repo, index) => {
+              const totalActivity = repo.additions + repo.deletions;
+              const width = `${Math.max(12, (totalActivity / repoActivityMax) * 100)}%`;
+              return (
+                <article key={repo.name} className="repo-card">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-3">
+                        <span className="repo-rank">{String(index + 1).padStart(2, "0")}</span>
+                        <h3 className="text-lg font-semibold text-foreground">{repo.name}</h3>
+                      </div>
+                      <p className="text-sm leading-6 text-muted">{repo.detail}</p>
+                    </div>
+                    <span className="repo-visibility">{repo.visibility}</span>
+                  </div>
+                  <div className="mt-4 space-y-3">
+                    <div className="repo-meter">
+                      <div className="repo-meter-fill" style={{ width }} />
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3 text-sm text-muted">
+                      <span>+{formatNumber(repo.additions)}</span>
+                      <span>-{formatNumber(repo.deletions)}</span>
+                      <span>{repo.commitCount} commits</span>
+                    </div>
+                  </div>
+                </article>
+              );
+            })
+          ) : (
+            <article className="repo-card">
+              <h3 className="text-lg font-semibold text-foreground">No synced repositories yet</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                Install the GitHub App, then run the first sync to populate repository metrics.
+              </p>
+            </article>
+          )}
+        </div>
+      </section>
+
+      <aside className="sidebar-panel">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="panel-label">Connected scope</p>
+            <h3 className="panel-heading">
+              {hasInstallations
+                ? `${installations.length} GitHub App installation${installations.length === 1 ? "" : "s"}`
+                : "No installation yet"}
+            </h3>
+          </div>
+          {connected ? (
+            <CheckCircle2 className="mt-1 h-5 w-5 text-[var(--success)]" />
+          ) : (
+            <Github className="mt-1 h-5 w-5 text-muted" />
+          )}
+        </div>
+
+        <p className="scope-summary">
+          {hasInstallations
+            ? `${formatNumber(accessibleRepositoryCount)} repositories are available in the current scope.`
+            : "Install the GitHub App on the account you want to measure to unlock repository-level metrics."}
+        </p>
+
+        {hasInstallations ? (
+          <div className="scope-list">
+            {installations.map((installation, index) => (
+              <article key={installation.id} className="scope-item">
+                <div className="scope-item-head">
+                  <div>
+                    <p className="scope-item-title">
+                      {installations.length === 1 ? "Primary scope" : installation.accountLogin}
+                    </p>
+                    <p className="scope-item-meta">{installation.repositoryCount} cached repos</p>
+                  </div>
+                  <form
+                    action={`/api/github/installations/${installation.githubInstallId}/sync`}
+                    method="post"
+                  >
+                    <button type="submit" className="button-secondary button-compact">
+                      <RefreshCcw className="h-4 w-4" />
+                      Refresh
+                    </button>
+                  </form>
+                </div>
+                <p className="scope-copy">
+                  {installation.repositoryNames.length > 0
+                    ? installation.repositoryNames.join(", ")
+                    : index === 0
+                      ? "Repository names will appear here after the next refresh."
+                      : "No repositories cached yet for this scope."}
+                </p>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="mt-5">
+            <ConnectionAction href="/api/github/install" label="Install GitHub App" />
+          </div>
+        )}
+      </aside>
+    </section>
+  );
 }
 
 const FALLBACK_GITHUB_STATE = {
@@ -450,15 +604,7 @@ export default async function Home({ searchParams }: HomePageProps) {
                 </div>
               </div>
 
-              <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                {dashboard.summary.map((item) => (
-                  <article key={item.label} className="metric-card">
-                    <p className="metric-label">{item.label}</p>
-                    <p className="metric-value">{item.value}</p>
-                    <p className="metric-detail">{item.detail}</p>
-                  </article>
-                ))}
-              </div>
+              <DashboardMetrics summary={dashboard.summary} />
             </section>
 
             <section className="story-panel">
@@ -510,134 +656,14 @@ export default async function Home({ searchParams }: HomePageProps) {
               )}
             </section>
 
-            <section className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_360px]">
-              <section className="story-panel">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <p className="panel-label">Repository pressure</p>
-                    <h3 className="panel-heading">Where the work landed</h3>
-                  </div>
-                  <span className="dashboard-pill">
-                    {dashboard.repositories.length} repos
-                  </span>
-                </div>
-
-                <div className="repo-list">
-                  {dashboard.repositories.length > 0 ? (
-                    dashboard.repositories.map((repo, index) => {
-                      const totalActivity = repo.additions + repo.deletions;
-                      const width = `${Math.max(12, (totalActivity / repoActivityMax) * 100)}%`;
-
-                      return (
-                        <article key={repo.name} className="repo-card">
-                          <div className="flex items-start justify-between gap-4">
-                            <div className="space-y-2">
-                              <div className="flex items-center gap-3">
-                                <span className="repo-rank">
-                                  {String(index + 1).padStart(2, "0")}
-                                </span>
-                                <h3 className="text-lg font-semibold text-foreground">
-                                  {repo.name}
-                                </h3>
-                              </div>
-                              <p className="text-sm leading-6 text-muted">{repo.detail}</p>
-                            </div>
-                            <span className="repo-visibility">{repo.visibility}</span>
-                          </div>
-
-                          <div className="mt-4 space-y-3">
-                            <div className="repo-meter">
-                              <div className="repo-meter-fill" style={{ width }} />
-                            </div>
-                            <div className="flex flex-wrap items-center gap-3 text-sm text-muted">
-                              <span>+{formatNumber(repo.additions)}</span>
-                              <span>-{formatNumber(repo.deletions)}</span>
-                              <span>{repo.commitCount} commits</span>
-                            </div>
-                          </div>
-                        </article>
-                      );
-                    })
-                  ) : (
-                    <article className="repo-card">
-                      <h3 className="text-lg font-semibold text-foreground">
-                        No synced repositories yet
-                      </h3>
-                      <p className="mt-2 text-sm leading-6 text-muted">
-                        Install the GitHub App, then run the first sync to populate repository metrics.
-                      </p>
-                    </article>
-                  )}
-                </div>
-              </section>
-
-              <aside className="sidebar-panel">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="panel-label">Connected scope</p>
-                    <h3 className="panel-heading">
-                      {hasInstallations
-                        ? `${githubState.installations.length} GitHub App installation${
-                            githubState.installations.length === 1 ? "" : "s"
-                          }`
-                        : "No installation yet"}
-                    </h3>
-                  </div>
-                  {githubState.connected ? (
-                    <CheckCircle2 className="mt-1 h-5 w-5 text-[var(--success)]" />
-                  ) : (
-                    <Github className="mt-1 h-5 w-5 text-muted" />
-                  )}
-                </div>
-
-                <p className="scope-summary">
-                  {hasInstallations
-                    ? `${formatNumber(accessibleRepositoryCount)} repositories are available in the current scope.`
-                    : "Install the GitHub App on the account you want to measure to unlock repository-level metrics."}
-                </p>
-
-                {hasInstallations ? (
-                  <div className="scope-list">
-                    {githubState.installations.map((installation, index) => (
-                      <article key={installation.id} className="scope-item">
-                        <div className="scope-item-head">
-                          <div>
-                            <p className="scope-item-title">
-                              {githubState.installations.length === 1
-                                ? "Primary scope"
-                                : installation.accountLogin}
-                            </p>
-                            <p className="scope-item-meta">
-                              {installation.repositoryCount} cached repos
-                            </p>
-                          </div>
-                          <form
-                            action={`/api/github/installations/${installation.githubInstallId}/sync`}
-                            method="post"
-                          >
-                            <button type="submit" className="button-secondary button-compact">
-                              <RefreshCcw className="h-4 w-4" />
-                              Refresh
-                            </button>
-                          </form>
-                        </div>
-                        <p className="scope-copy">
-                          {installation.repositoryNames.length > 0
-                            ? installation.repositoryNames.join(", ")
-                            : index === 0
-                              ? "Repository names will appear here after the next refresh."
-                              : "No repositories cached yet for this scope."}
-                        </p>
-                      </article>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="mt-5">
-                    <ConnectionAction href="/api/github/install" label="Install GitHub App" />
-                  </div>
-                )}
-              </aside>
-            </section>
+            <RepoSection
+              repositories={dashboard.repositories}
+              repoActivityMax={repoActivityMax}
+              installations={githubState.installations}
+              connected={githubState.connected}
+              hasInstallations={hasInstallations}
+              accessibleRepositoryCount={accessibleRepositoryCount}
+            />
           </>
         ) : (
           <section id="dashboard" className="dashboard-shell">

--- a/src/components/activity-bar-chart.tsx
+++ b/src/components/activity-bar-chart.tsx
@@ -72,7 +72,7 @@ export function ActivityBarChart({ chartGeometry, timelineLength, view, chartTit
       <svg
         ref={svgRef}
         viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
-        className="h-[24rem] w-full"
+        className="h-[14rem] w-full sm:h-[20rem] md:h-[24rem]"
         role="img"
         aria-label={`${chartTitle} additions and deletions bar chart`}
       >
@@ -111,7 +111,7 @@ export function ActivityBarChart({ chartGeometry, timelineLength, view, chartTit
               y={bar.additions.y}
               width={chartGeometry.barWidth}
               height={bar.additions.height}
-              rx="0"
+              rx="3"
               fill="#6e84ad"
               onMouseEnter={(e) => handleBarMouseEnter(bar.label, "additions", bar.additionsValue, e)}
               onMouseLeave={handleBarMouseLeave}
@@ -122,7 +122,7 @@ export function ActivityBarChart({ chartGeometry, timelineLength, view, chartTit
               y={bar.deletions.y}
               width={chartGeometry.barWidth}
               height={bar.deletions.height}
-              rx="0"
+              rx="3"
               fill="#d4a06a"
               onMouseEnter={(e) => handleBarMouseEnter(bar.label, "deletions", bar.deletionsValue, e)}
               onMouseLeave={handleBarMouseLeave}

--- a/src/components/activity-sync-refresh.tsx
+++ b/src/components/activity-sync-refresh.tsx
@@ -11,12 +11,38 @@ export function ActivitySyncRefresh({ active }: { active: boolean }) {
       return;
     }
 
-    const interval = window.setInterval(() => {
-      router.refresh();
-    }, 4000);
+    let intervalId: number | null = null;
+
+    function startPolling() {
+      if (document.visibilityState === "hidden" || intervalId !== null) return;
+      intervalId = window.setInterval(() => {
+        if (document.visibilityState !== "hidden") {
+          router.refresh();
+        }
+      }, 8000);
+    }
+
+    function stopPolling() {
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+        intervalId = null;
+      }
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === "hidden") {
+        stopPolling();
+      } else {
+        startPolling();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    startPolling();
 
     return () => {
-      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      stopPolling();
     };
   }, [active, router]);
 


### PR DESCRIPTION
## Summary

- **Dark mode** — full `@media (prefers-color-scheme: dark)` implementation with a warm charcoal palette (`#1a1714` bg, `#e8e0d5` fg) that preserves the app's editorial character. Covers all panels, cards, buttons, toggle pills, chart shell, status notes, SVG grid lines/tick text, and `bg-white/*` Tailwind utility overrides for social-shell surfaces. Removes forced `colorScheme: "light"` from `<html>` and adds `color-scheme: light dark` to `:root`.
- **Remove IBM Plex Mono** — the font was loaded but never visibly used; removed from `layout.tsx`, saving one Google Fonts request. `--font-mono` falls back to the system monospace stack.
- **Polling optimisation** — `ActivitySyncRefresh` interval doubled (4 s → 8 s); interval is torn down entirely when the tab is hidden via `visibilitychange` and restarted on focus.
- **Responsive bar chart** — SVG height is now `14rem` on mobile / `20rem` on sm / `24rem` on md+. Bar corners changed to `rx="3"` for a subtly rounded finish.
- **Code cleanup** — removed dead `shouldShowXAxisLabel` duplicate from `page.tsx`; extracted `DashboardMetrics` and `RepoSection` as named components, slimming the `Home` render function by ~150 lines.

## Test plan

- [ ] Light mode: visually identical to before on desktop and mobile
- [ ] Dark mode (toggle via System Preferences or DevTools emulation): all surfaces render with warm-dark palette; text, buttons, chart, and form inputs are readable
- [ ] Mobile (≤640 px): chart renders at 14 rem height, not clipped
- [ ] Background tab: no network requests while tab is hidden; polling resumes on focus (DevTools Network tab)
- [ ] No IBM Plex Mono font requests in Network tab
- [ ] `tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)