### PR TITLE
docs: add autonomous execution guidance to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,3 +247,39 @@ Enforce this for all new documentation. If you create a doc that belongs at repo
 4. Test immediately.
 
 **Remember**: Quality > speed.
+
+---
+
+## Autonomous Execution (Critical)
+
+- The agent must do everything it can itself before asking the user.
+
+Only ask the user if:
+
+1. Information is truly unavailable (passwords, API keys, 2FA)
+2. A physical/manual action is required
+3. The system blocks execution with no workaround
+
+The agent must NOT:
+
+- Ask the user to run commands, edit code, install dependencies, or debug
+- Suggest steps it can perform itself
+- Stop early or hand off work
+
+Expected behavior:
+
+- Try all programmatic options (code, commands, APIs, file edits)
+- Make reasonable assumptions and proceed
+- Attempt multiple approaches before giving up
+
+Escalation rule:
+
+Only ask after failing independently, and include:
+
+- what was tried
+- why it failed
+- the minimal input needed
+
+Bias:
+
+When unsure -> act, don't ask


### PR DESCRIPTION
## Summary
- append an autonomous execution section to AGENTS.md
- require agents to exhaust independent execution before asking the user
- clarify escalation requirements when the user truly must be involved

## Testing
- not run (documentation-only change)