### PR TITLE
fix: stop auth CTA prefetch from triggering OAuth CORS noise

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/cloudflare-read";
 import { formatNumber } from "@/lib/dashboard";
 import type { AnalyticsView, MetricMode } from "@/lib/dashboard";
+import { getLinkPrefetch } from "@/lib/link-prefetch";
 
 type HomePageProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
@@ -176,6 +177,7 @@ function ConnectionAction({
   return (
     <Link
       href={href}
+      prefetch={getLinkPrefetch(href)}
       className={tone === "primary" ? "button-primary w-full sm:w-auto" : "button-secondary w-full sm:w-auto"}
     >
       {label}

--- a/src/app/social/invite/[token]/page.tsx
+++ b/src/app/social/invite/[token]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { SocialInviteCard } from "@/components/social-invite-card";
 import { fetchCloudflareReadJson, hasCloudflareWorkerProxy } from "@/lib/cloudflare-read";
+import { getLinkPrefetch } from "@/lib/link-prefetch";
 
 type SocialInvitePayload = {
   token: string;
@@ -47,7 +48,14 @@ export default async function SocialInvitePage({ params }: InvitePageProps) {
           expiresAt={invite.expiresAt}
         />
         <div className="text-sm text-muted">
-          Need GitHub first? <Link href="/api/github/connect" className="underline">Connect now</Link>
+          Need to connect first?{" "}
+          <Link
+            href="/api/github/connect"
+            prefetch={getLinkPrefetch("/api/github/connect")}
+            className="underline"
+          >
+            Continue with GitHub
+          </Link>
         </div>
       </div>
     </main>

--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRight, ShieldCheck, Sparkles, Users } from "lucide-react";
 
 import { SocialShell } from "@/components/social-shell";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { getLinkPrefetch } from "@/lib/link-prefetch";
 import {
   fetchCloudflareReadJson,
   hasCloudflareSessionCookie,
@@ -37,7 +38,11 @@ export default async function SocialPage({ searchParams }: SocialPageProps) {
                 </p>
               </div>
               <div className="hero-actions">
-                <Link href="/api/github/connect" className="button-primary">
+                <Link
+                  href="/api/github/connect"
+                  prefetch={getLinkPrefetch("/api/github/connect")}
+                  className="button-primary"
+                >
                   Continue with GitHub
                 </Link>
                 <Link href="/" className="button-secondary">

--- a/src/lib/link-prefetch.test.ts
+++ b/src/lib/link-prefetch.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { getLinkPrefetch } from "@/lib/link-prefetch";
+
+describe("getLinkPrefetch", () => {
+  it("disables prefetch for API route navigations", () => {
+    expect(getLinkPrefetch("/api/github/connect")).toBe(false);
+    expect(getLinkPrefetch("/api/github/install")).toBe(false);
+    expect(getLinkPrefetch("/api/session/reset")).toBe(false);
+  });
+
+  it("keeps default prefetch behavior for app pages", () => {
+    expect(getLinkPrefetch("/")).toBeUndefined();
+    expect(getLinkPrefetch("/privacy")).toBeUndefined();
+    expect(getLinkPrefetch("/social")).toBeUndefined();
+  });
+});

--- a/src/lib/link-prefetch.ts
+++ b/src/lib/link-prefetch.ts
@@ -1,0 +1,3 @@
+export function getLinkPrefetch(href: string) {
+  return href.startsWith("/api/") ? false : undefined;
+}


### PR DESCRIPTION
## Summary
- stop Next.js prefetching for internal API-route links so auth CTAs do not fetch OAuth redirects in the background
- apply the rule to the homepage connection actions, signed-out social page, and social invite page
- add a regression test for the shared prefetch decision helper

## Verification
- npm run lint
- npm test -- src/lib/link-prefetch.test.ts src/app/api/github/connect/route.test.ts

Closes #93
