### PR TITLE
fix: sync existing github installs before redirecting

### DIFF
--- a/cloudflare/worker/src/jobs/consumer.ts
+++ b/cloudflare/worker/src/jobs/consumer.ts
@@ -66,6 +66,11 @@ export async function handleQueueBatch(
         continue;
       }
 
+      console.error("Queue message failed", {
+        messageId: message.id,
+        body: message.body,
+        error: error instanceof Error ? error.message : String(error),
+      });
       message.retry();
     }
   }

--- a/cloudflare/worker/src/lib/github.ts
+++ b/cloudflare/worker/src/lib/github.ts
@@ -92,11 +92,30 @@ function encodeBase64Url(input: string | ArrayBuffer) {
 }
 
 function decodePemPrivateKey(privateKey: string) {
-  const normalized = privateKey
+  const trimmed = privateKey.trim();
+  if (trimmed.includes("BEGIN RSA PRIVATE KEY")) {
+    throw new Error(
+      "GitHub private key must be stored in PKCS#8 format (BEGIN PRIVATE KEY).",
+    );
+  }
+
+  const normalized = trimmed
+    .trim()
+    .replace(/^"|"$/g, "")
+    .replace(/\\r/g, "")
+    .replace(/\\n/g, "\n")
     .replace(/-----BEGIN PRIVATE KEY-----/g, "")
     .replace(/-----END PRIVATE KEY-----/g, "")
-    .replace(/\s+/g, "");
-  const binary = atob(normalized);
+    .replace(/\s+/g, "")
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  let binary: string;
+
+  try {
+    binary = atob(normalized);
+  } catch {
+    throw new Error("GitHub private key secret is not valid base64.");
+  }
   const bytes = new Uint8Array(binary.length);
 
   for (let index = 0; index < binary.length; index += 1) {

--- a/cloudflare/worker/src/routes/control.ts
+++ b/cloudflare/worker/src/routes/control.ts
@@ -44,6 +44,11 @@ function redirect(url: string, headers = new Headers()) {
   });
 }
 
+function getAppRedirectUrl(env: VibeWorkerEnv, request: Request, pathWithQuery: string) {
+  const baseUrl = env.APP_URL ?? new URL(request.url).origin;
+  return new URL(pathWithQuery, baseUrl).toString();
+}
+
 function getReconnectState(url: string) {
   return {
     connected: false,
@@ -287,7 +292,35 @@ export async function handleGitHubState(request: Request, env: VibeWorkerEnv) {
 
 export async function handleGitHubInstall(request: Request, env: VibeWorkerEnv) {
   if (!hasGitHubAuthEnv(env) || !env.GITHUB_APP_SLUG) {
-    return redirect(new URL("/?github=missing-config", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=missing-config"));
+  }
+
+  const session = await getValidUserAccessToken(env, request);
+
+  if (session) {
+    try {
+      const installations = await getUserInstallations(session.accessToken);
+      const queued = await enqueueInstallationMessages(
+        env,
+        session.accountId,
+        installations.map((installation) => ({
+          githubInstallationId: installation.id,
+          accountLogin: installation.account.login,
+          accountType: installation.account.type,
+          targetType: installation.target_type ?? null,
+          permissions: installation.permissions,
+        })),
+      );
+
+      if (queued) {
+        return redirect(getAppRedirectUrl(env, request, "/?github=installation-connected"));
+      }
+    } catch (error) {
+      console.error("Failed to sync existing GitHub installations during install", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return redirect(getAppRedirectUrl(env, request, "/?github=sync-failed"));
+    }
   }
 
   return redirect(
@@ -297,12 +330,12 @@ export async function handleGitHubInstall(request: Request, env: VibeWorkerEnv) 
 
 export async function handleGitHubSetup(request: Request, env: VibeWorkerEnv) {
   if (!hasGitHubAuthEnv(env)) {
-    return redirect(new URL("/?github=missing-config", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=missing-config"));
   }
 
   const session = await getValidUserAccessToken(env, request);
   if (!session) {
-    return redirect(new URL("/?github=not-connected", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=not-connected"));
   }
 
   const installationId = Number.parseInt(
@@ -310,14 +343,14 @@ export async function handleGitHubSetup(request: Request, env: VibeWorkerEnv) {
     10,
   );
   if (Number.isNaN(installationId)) {
-    return redirect(new URL("/?github=invalid-installation", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=invalid-installation"));
   }
 
   try {
     const installations = await getUserInstallations(session.accessToken);
     const installation = installations.find((entry) => entry.id === installationId);
     if (!installation) {
-      return redirect(new URL("/?github=invalid-installation", request.url).toString());
+      return redirect(getAppRedirectUrl(env, request, "/?github=invalid-installation"));
     }
 
     const queued = await enqueueInstallationMessages(env, session.accountId, [
@@ -331,14 +364,16 @@ export async function handleGitHubSetup(request: Request, env: VibeWorkerEnv) {
     ]);
 
     if (!queued) {
-      return redirect(new URL("/?github=sync-failed", request.url).toString());
+      return redirect(getAppRedirectUrl(env, request, "/?github=sync-failed"));
     }
 
-    return redirect(
-      new URL("/?github=installation-connected", request.url).toString(),
-    );
-  } catch {
-    return redirect(new URL("/?github=sync-failed", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=installation-connected"));
+  } catch (error) {
+    console.error("Failed to complete GitHub installation setup", {
+      installationId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return redirect(getAppRedirectUrl(env, request, "/?github=sync-failed"));
   }
 }
 
@@ -347,12 +382,12 @@ export async function handleGitHubActivitySync(
   env: VibeWorkerEnv,
 ) {
   if (!hasGitHubAuthEnv(env)) {
-    return redirect(new URL("/?github=missing-config", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=missing-config"));
   }
 
   const accountId = await getRequestAccountId(request, env);
   if (!accountId) {
-    return redirect(new URL("/?github=not-connected", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=not-connected"));
   }
 
   const installations = await listInstallationsForAccount(env, accountId);
@@ -363,12 +398,10 @@ export async function handleGitHubActivitySync(
   );
 
   if (!queued) {
-    return redirect(new URL("/?github=sync-failed", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=sync-failed"));
   }
 
-  return redirect(
-    new URL("/?github=activity-sync-started", request.url).toString(),
-  );
+  return redirect(getAppRedirectUrl(env, request, "/?github=activity-sync-started"));
 }
 
 export async function handleGitHubInstallationSync(
@@ -378,7 +411,7 @@ export async function handleGitHubInstallationSync(
 ) {
   const accountId = await getRequestAccountId(request, env);
   if (!accountId) {
-    return redirect(new URL("/?github=not-connected", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=not-connected"));
   }
 
   const installations = await listInstallationsForAccount(env, accountId);
@@ -387,7 +420,7 @@ export async function handleGitHubInstallationSync(
   );
 
   if (!installation) {
-    return redirect(new URL("/?github=invalid-installation", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=invalid-installation"));
   }
 
   const queued = await enqueueInstallationMessages(env, accountId, [
@@ -395,12 +428,10 @@ export async function handleGitHubInstallationSync(
   ]);
 
   if (!queued) {
-    return redirect(new URL("/?github=sync-failed", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=sync-failed"));
   }
 
-  return redirect(
-    new URL("/?github=repositories-refreshed", request.url).toString(),
-  );
+  return redirect(getAppRedirectUrl(env, request, "/?github=repositories-refreshed"));
 }
 
 export async function handleGitHubInstallationScope(
@@ -410,7 +441,7 @@ export async function handleGitHubInstallationScope(
 ) {
   const accountId = await getRequestAccountId(request, env);
   if (!accountId) {
-    return redirect(new URL("/?github=not-connected", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=not-connected"));
   }
 
   const installations = await listInstallationsForAccount(env, accountId);
@@ -419,7 +450,7 @@ export async function handleGitHubInstallationScope(
   );
 
   if (!installation) {
-    return redirect(new URL("/?github=invalid-installation", request.url).toString());
+    return redirect(getAppRedirectUrl(env, request, "/?github=invalid-installation"));
   }
 
   const formData = await request.formData();
@@ -436,7 +467,7 @@ export async function handleGitHubInstallationScope(
 
   if (selectedRepositoryIds.length > MAX_TRACKED_REPOSITORIES_PER_INSTALLATION) {
     return redirect(
-      new URL("/?github=repository-scope-too-large", request.url).toString(),
+      getAppRedirectUrl(env, request, "/?github=repository-scope-too-large"),
     );
   }
 
@@ -466,9 +497,7 @@ export async function handleGitHubInstallationScope(
     ).bind(Date.now(), Date.now(), installation.id),
   ]);
 
-  return redirect(
-    new URL("/?github=repository-scope-saved", request.url).toString(),
-  );
+  return redirect(getAppRedirectUrl(env, request, "/?github=repository-scope-saved"));
 }
 
 export async function handleSocialProfileUpdate(

--- a/cloudflare/worker/test/routes-control-install.test.ts
+++ b/cloudflare/worker/test/routes-control-install.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { handleGitHubInstall } from "@/routes/control";
+import type { VibeWorkerEnv } from "@/env";
+
+const { getValidUserAccessTokenMock, getUserInstallationsMock } = vi.hoisted(() => ({
+  getValidUserAccessTokenMock: vi.fn(),
+  getUserInstallationsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/session", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/session")>("@/lib/session");
+  return {
+    ...actual,
+    getValidUserAccessToken: getValidUserAccessTokenMock,
+  };
+});
+
+vi.mock("@/lib/github", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/github")>("@/lib/github");
+  return {
+    ...actual,
+    getUserInstallations: getUserInstallationsMock,
+  };
+});
+
+function createEnv(overrides: Partial<VibeWorkerEnv> = {}) {
+  return {
+    APP_URL: "https://vibe-tracker-max.vercel.app",
+    DB: {} as D1Database,
+    GITHUB_APP_CLIENT_ID: "client-id",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_SLUG: "vibe-tracker-rb",
+    SESSION_ENCRYPTION_KEY: "session-key",
+    SYNC_QUEUE: {
+      send: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Queue,
+    ...overrides,
+  } satisfies VibeWorkerEnv;
+}
+
+describe("handleGitHubInstall", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getValidUserAccessTokenMock.mockReset();
+    getUserInstallationsMock.mockReset();
+  });
+
+  it("queues existing installations for signed-in users instead of bouncing back to GitHub", async () => {
+    const env = createEnv();
+    getValidUserAccessTokenMock.mockResolvedValue({
+      accountId: "account-1",
+      accessToken: "access-token",
+    });
+    getUserInstallationsMock.mockResolvedValue([
+      {
+        id: 115689046,
+        account: {
+          login: "rudrakshbhandari",
+          type: "User",
+        },
+        target_type: "user",
+        permissions: {
+          contents: "read",
+        },
+      },
+    ]);
+
+    const response = await handleGitHubInstall(
+      new Request("https://vibe-tracker-max.vercel.app/api/github/install"),
+      env,
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://vibe-tracker-max.vercel.app/?github=installation-connected",
+    );
+    expect(env.SYNC_QUEUE.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the GitHub install page when no session exists", async () => {
+    const env = createEnv();
+    getValidUserAccessTokenMock.mockResolvedValue(null);
+
+    const response = await handleGitHubInstall(
+      new Request("https://vibe-tracker-max.vercel.app/api/github/install"),
+      env,
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://github.com/apps/vibe-tracker-rb/installations/new",
+    );
+  });
+
+  it("redirects failures back to the app origin instead of the worker origin", async () => {
+    const env = createEnv();
+    getValidUserAccessTokenMock.mockResolvedValue({
+      accountId: "account-1",
+      accessToken: "access-token",
+    });
+    getUserInstallationsMock.mockRejectedValue(new Error("GitHub exploded"));
+
+    const response = await handleGitHubInstall(
+      new Request("https://vibe-tracker-worker.rudrakshbhandari99.workers.dev/api/github/install"),
+      env,
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://vibe-tracker-max.vercel.app/?github=sync-failed",
+    );
+  });
+});

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -1,5 +1,34 @@
 # Execution Plan
 
+## Issue #115 - Debug production installation discovery after GitHub App install
+
+- Issue: [#115](https://github.com/rudrakshbhandari/vibe-tracker/issues/115)
+- Branch: `rudrakshbhandari/debug-installation-discovery`
+- PR: [#116](https://github.com/rudrakshbhandari/vibe-tracker/pull/116)
+- Workflow: In Review
+- Priority: P1
+- App: multi
+
+### Checklist
+
+- [x] Create the follow-up issue and task branch
+- [x] Trace the production worker install discovery path and confirm the missing D1 installation rows
+- [x] Fix `/api/github/install` so existing signed-in installations enqueue sync instead of bouncing back to GitHub
+- [x] Add worker coverage for the existing-installation install flow
+- [x] Run worker verification locally
+- [x] Push branch, open PR, deploy, and confirm production installation discovery and first sync
+
+### Verification
+
+- `npm run cloudflare:test -- routes-control-install.test.ts`
+- `npm run cloudflare:test`
+- `npm run cloudflare:typecheck`
+- `npx wrangler deploy --config cloudflare/worker/wrangler.jsonc`
+- Production smoke:
+  - `/api/github/install` redirects back to the app with `?github=installation-connected`
+  - D1 now contains the production installation grant and synced repositories
+  - dashboard now shows `1 GitHub App installation` and `25/33 tracked repos`
+
 ## Issue #113 - Fix worker-backed read API status propagation
 
 - Issue: [#113](https://github.com/rudrakshbhandari/vibe-tracker/issues/113)


### PR DESCRIPTION
## Summary
- sync existing GitHub App installations when an authenticated user hits `/api/github/install`
- avoid the stuck state where GitHub shows an installed app but D1 never gets installation rows
- add worker coverage for the existing-installation recovery path

## Verification
- `npm run cloudflare:test -- routes-control-install.test.ts`
- `npm run cloudflare:test`
- `npm run cloudflare:typecheck`

Closes #115
