### PR TITLE
fix: switch shipped-work chart to single scale

### DIFF
--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -4,8 +4,8 @@
 
 - Issue: [#143](https://github.com/rudrakshbhandari/vibe-tracker/issues/143)
 - Branch: `rudrakshbhandari/chart-single-scale`
-- PR: pending
-- Workflow: In Progress
+- PR: [#144](https://github.com/rudrakshbhandari/vibe-tracker/pull/144)
+- Workflow: In Review
 - Priority: P2
 - App: multi
 
@@ -15,7 +15,7 @@
 - [x] Rework the chart back to a shared upward scale while keeping the outlier cap
 - [x] Update chart copy and labels to match the single-scale layout
 - [x] Run local verification (`npm run lint`, `npm test`, `npm run build`)
-- [ ] Open PR and update project tracking
+- [x] Open PR and update project tracking
 
 ### Verification
 

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -1,5 +1,28 @@
 # Execution Plan
 
+## Issue #143 - Switch shipped-work chart back to single-scale layout
+
+- Issue: [#143](https://github.com/rudrakshbhandari/vibe-tracker/issues/143)
+- Branch: `rudrakshbhandari/chart-single-scale`
+- PR: pending
+- Workflow: In Progress
+- Priority: P2
+- App: multi
+
+### Checklist
+
+- [x] Reproduce the chart regression and confirm the mirrored layout is wasting vertical space
+- [x] Rework the chart back to a shared upward scale while keeping the outlier cap
+- [x] Update chart copy and labels to match the single-scale layout
+- [x] Run local verification (`npm run lint`, `npm test`, `npm run build`)
+- [ ] Open PR and update project tracking
+
+### Verification
+
+- `npm run lint`
+- `npm test`
+- `npm run build`
+
 ## Issue #138 - Refine shipped-work chart UI and scale readability
 
 - Issue: [#138](https://github.com/rudrakshbhandari/vibe-tracker/issues/138)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -231,16 +231,14 @@ function buildBarChartGeometry(timeline: TimelinePoint[]) {
   const groupWidth = innerWidth / Math.max(timeline.length, 1);
   const barWidth = Math.min(22, Math.max(10, groupWidth * 0.28));
   const barGap = Math.max(4, groupWidth * 0.08);
-  const centerGap = 18;
-  const halfHeight = (innerHeight - centerGap) / 2;
-  const baselineY = CHART_PADDING.top + halfHeight + centerGap / 2;
+  const baselineY = CHART_PADDING.top + innerHeight;
 
   const toHeight = (value: number) => {
     if (value <= 0) {
       return 0;
     }
 
-    return Math.max(6, (Math.min(value, displayMaxValue) / displayMaxValue) * halfHeight);
+    return Math.max(6, (Math.min(value, displayMaxValue) / displayMaxValue) * innerHeight);
   };
 
   const bars = timeline.map((point, index) => {
@@ -261,7 +259,7 @@ function buildBarChartGeometry(timeline: TimelinePoint[]) {
       },
       deletions: {
         x: centerX + barGap / 2,
-        y: baselineY,
+        y: baselineY - deletionsHeight,
         height: deletionsHeight,
         truncated: point.deletions > displayMaxValue,
       },
@@ -889,7 +887,7 @@ export default async function Home({ searchParams }: HomePageProps) {
                   <p className="panel-label">{dashboard.chartTitle}</p>
                   <h3 className="panel-heading">Lines changed by ship period</h3>
                   <p className="chart-intro">
-                    Additions rise above the center line and deletions drop below it so the direction stays obvious at a glance.
+                    Additions and deletions share one upward scale so the busiest periods stay easy to compare at a glance.
                     {chartGeometry?.hasScaleBreak
                       ? ` The scale is capped at ${formatNumber(chartGeometry.displayMaxValue)} lines to keep non-peak periods readable.`
                       : " The vertical scale stays linear across the full selected range."}
@@ -929,9 +927,9 @@ export default async function Home({ searchParams }: HomePageProps) {
                       <p className="chart-stat-detail">Median combined line change for non-zero periods in this view.</p>
                     </article>
                     <article className="chart-stat-card">
-                      <p className="panel-label">Visible chart range</p>
+                      <p className="panel-label">Visible chart ceiling</p>
                       <p className="chart-stat-value">
-                        ±{formatNumber(chartGeometry.displayMaxValue)}
+                        {formatNumber(chartGeometry.displayMaxValue)}
                       </p>
                       <p className="chart-stat-detail">
                         {chartGeometry.hasScaleBreak

--- a/src/components/activity-bar-chart.tsx
+++ b/src/components/activity-bar-chart.tsx
@@ -97,53 +97,31 @@ export function ActivityBarChart({ chartGeometry, timelineLength, view, chartTit
         viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
         className="h-[14rem] w-full sm:h-[20rem] md:h-[24rem]"
         role="img"
-        aria-label={`${chartTitle} additions above zero and deletions below zero bar chart${chartGeometry.hasScaleBreak ? ", with overflow caps for outlier periods" : ""}`}
+        aria-label={`${chartTitle} additions and deletions bar chart on a shared upward scale${chartGeometry.hasScaleBreak ? ", with overflow caps for outlier periods" : ""}`}
       >
         {chartGeometry.ticks.map((tick) => {
-          const ratio = tick <= 0 ? 0 : tick / chartGeometry.displayMaxValue;
-          const offset = ratio * ((chartGeometry.innerHeight - 18) / 2);
-          const topY = chartGeometry.baselineY - offset;
-          const bottomY = chartGeometry.baselineY + offset;
+          const y =
+            chartGeometry.baselineY -
+            (tick <= 0 ? 0 : (tick / chartGeometry.displayMaxValue) * chartGeometry.innerHeight);
           return (
             <g key={tick}>
               <line
                 x1={CHART_PADDING.left}
                 x2={CHART_WIDTH - CHART_PADDING.right}
-                y1={topY}
-                y2={topY}
+                y1={y}
+                y2={y}
                 stroke="rgba(89, 98, 112, 0.16)"
                 strokeDasharray="4 10"
               />
               <text
                 x={CHART_PADDING.left - 12}
-                y={topY + 4}
+                y={y + 4}
                 textAnchor="end"
                 fill="rgba(91, 99, 111, 0.85)"
                 fontSize="12"
               >
                 {tick === 0 ? "0" : formatNumber(tick)}
               </text>
-              {tick > 0 ? (
-                <>
-                  <line
-                    x1={CHART_PADDING.left}
-                    x2={CHART_WIDTH - CHART_PADDING.right}
-                    y1={bottomY}
-                    y2={bottomY}
-                    stroke="rgba(89, 98, 112, 0.1)"
-                    strokeDasharray="4 10"
-                  />
-                  <text
-                    x={CHART_PADDING.left - 12}
-                    y={bottomY + 4}
-                    textAnchor="end"
-                    fill="rgba(91, 99, 111, 0.78)"
-                    fontSize="12"
-                  >
-                    -{formatNumber(tick)}
-                  </text>
-                </>
-              ) : null}
             </g>
           );
         })}
@@ -157,10 +135,7 @@ export function ActivityBarChart({ chartGeometry, timelineLength, view, chartTit
         />
 
         <text x={CHART_PADDING.left} y={CHART_PADDING.top - 2} className="chart-axis-caption">
-          Additions
-        </text>
-        <text x={CHART_PADDING.left} y={CHART_HEIGHT - CHART_PADDING.bottom + 28} className="chart-axis-caption">
-          Deletions
+          Lines changed
         </text>
 
         {chartGeometry.bars.map((bar, index) => (
@@ -235,8 +210,8 @@ export function ActivityBarChart({ chartGeometry, timelineLength, view, chartTit
                 <line
                   x1={bar.deletions.x}
                   x2={bar.deletions.x + chartGeometry.barWidth}
-                  y1={bar.deletions.y + bar.deletions.height - 3}
-                  y2={bar.deletions.y + bar.deletions.height - 3}
+                  y1={bar.deletions.y + 3}
+                  y2={bar.deletions.y + 3}
                   className="chart-overflow-cap"
                 />
               ) : null}


### PR DESCRIPTION
## Summary
- switch the shipped-work chart back to a single upward scale
- keep the outlier cap behavior so normal periods remain readable
- update the chart copy and labels so they match the single-scale presentation
- update execution tracking for Issue #143

## Verification
- npm run lint
- npm test
- npm run build

Closes #143