### PR TITLE
redesign: minimal Apple-clean homepage

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,25 +2,28 @@
 
 :root {
   color-scheme: light;
-  --background: #fbfbfd;
+  --background: #f2f2f5;
   --foreground: #1d1d1f;
   --panel: #ffffff;
   --panel-strong: #ffffff;
   --panel-soft: #f5f5f7;
+  --panel-inset: #fafafc;
   --muted: #6e6e73;
   --muted-strong: #424245;
-  --line: rgba(0, 0, 0, 0.08);
-  --line-strong: rgba(0, 0, 0, 0.14);
+  --line: rgba(0, 0, 0, 0.09);
+  --line-strong: rgba(0, 0, 0, 0.16);
   --accent: #0071e3;
   --accent-strong: #0077ed;
+  --accent-soft: rgba(0, 113, 227, 0.08);
   --accent-2: #0071e3;
   --danger: #e0404a;
   --warning: #c48a12;
   --success: #1f8a3a;
+  --success-soft: rgba(31, 138, 58, 0.12);
   --button-primary-fg: #ffffff;
   --button-secondary-bg: #f5f5f7;
-  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
-  --shadow-raised: 0 4px 14px rgba(0, 0, 0, 0.06);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 12px rgba(0, 0, 0, 0.04);
+  --shadow-raised: 0 6px 24px rgba(0, 0, 0, 0.08);
 }
 
 @theme inline {
@@ -68,9 +71,19 @@ a {
   overflow-x: clip;
 }
 
-/* Decorative wash — intentionally blank in the minimal theme. */
+.page-shell > div {
+  position: relative;
+  z-index: 1;
+}
+
 .page-wash {
-  display: none;
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(60% 40% at 85% -10%, rgba(0, 113, 227, 0.08), transparent 70%),
+    radial-gradient(50% 40% at -10% 10%, rgba(88, 86, 214, 0.05), transparent 70%);
 }
 
 /* ---------- Surfaces ---------- */
@@ -184,15 +197,36 @@ a {
 
 .panel-label,
 .metric-label {
-  color: var(--muted);
-  font-size: 0.8125rem;
-  font-weight: 500;
-  letter-spacing: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
   text-transform: none;
 }
 
+.panel-label::before {
+  content: "";
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 9999px;
+  background: var(--accent);
+}
+
+.metric-label {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.metric-label::before {
+  display: none;
+}
+
 .panel-label + .panel-heading {
-  margin-top: 0.35rem;
+  margin-top: 0.5rem;
 }
 
 .dashboard-pill,
@@ -207,6 +241,23 @@ a {
   font-size: 0.8125rem;
   text-transform: none;
   letter-spacing: 0;
+}
+
+.dashboard-pill {
+  border-color: rgba(0, 113, 227, 0.22);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.dashboard-pill::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.15);
 }
 
 .repo-rank {
@@ -233,8 +284,49 @@ a {
   gap: 1rem;
   border-radius: 14px;
   border: 1px solid var(--line);
-  background: var(--panel-soft);
+  background:
+    linear-gradient(180deg, var(--panel-inset), var(--panel-soft));
   padding: 1.25rem;
+}
+
+.hero-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  width: fit-content;
+  border-radius: 9999px;
+  border: 1px solid rgba(0, 113, 227, 0.22);
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.3rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.hero-kicker::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.15);
+}
+
+.status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 9999px;
+  background: var(--muted);
+  margin-right: 0.4rem;
+  vertical-align: middle;
+}
+
+.status-dot-live {
+  background: var(--success);
+  box-shadow: 0 0 0 3px var(--success-soft);
 }
 
 .meta-stack {
@@ -433,15 +525,19 @@ a {
   flex-direction: column;
   gap: 0.5rem;
   min-height: 100%;
+  background:
+    linear-gradient(180deg, rgba(0, 113, 227, 0.025), transparent 40%),
+    var(--panel);
 }
 
 .metric-value {
   font-family: inherit;
-  font-size: clamp(1.75rem, 2.6vw, 2.25rem);
+  font-size: clamp(1.875rem, 2.8vw, 2.5rem);
   font-weight: 600;
-  letter-spacing: -0.035em;
+  letter-spacing: -0.04em;
   line-height: 1;
   font-variant-numeric: tabular-nums;
+  color: var(--foreground);
 }
 
 .metric-detail {
@@ -816,20 +912,35 @@ a {
     --panel: #1c1c1e;
     --panel-strong: #1c1c1e;
     --panel-soft: #161618;
+    --panel-inset: #1f1f22;
     --muted: #98989d;
     --muted-strong: #c7c7cc;
     --line: rgba(255, 255, 255, 0.1);
     --line-strong: rgba(255, 255, 255, 0.18);
     --accent: #0a84ff;
     --accent-strong: #409cff;
+    --accent-soft: rgba(10, 132, 255, 0.14);
     --accent-2: #0a84ff;
     --danger: #ff453a;
     --warning: #ffd60a;
     --success: #30d158;
+    --success-soft: rgba(48, 209, 88, 0.18);
     --button-primary-fg: #ffffff;
     --button-secondary-bg: #1c1c1e;
-    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.5);
-    --shadow-raised: 0 4px 14px rgba(0, 0, 0, 0.6);
+    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.5), 0 4px 16px rgba(0, 0, 0, 0.35);
+    --shadow-raised: 0 6px 24px rgba(0, 0, 0, 0.6);
+  }
+
+  :root:not([data-theme="light"]) .page-wash {
+    background:
+      radial-gradient(60% 40% at 85% -10%, rgba(10, 132, 255, 0.10), transparent 70%),
+      radial-gradient(50% 40% at -10% 10%, rgba(94, 92, 230, 0.06), transparent 70%);
+  }
+
+  :root:not([data-theme="light"]) .metric-card {
+    background:
+      linear-gradient(180deg, rgba(10, 132, 255, 0.06), transparent 40%),
+      var(--panel);
   }
 
   :root:not([data-theme="light"]) .repo-meter {
@@ -876,20 +987,35 @@ a {
   --panel: #1c1c1e;
   --panel-strong: #1c1c1e;
   --panel-soft: #161618;
+  --panel-inset: #1f1f22;
   --muted: #98989d;
   --muted-strong: #c7c7cc;
   --line: rgba(255, 255, 255, 0.1);
   --line-strong: rgba(255, 255, 255, 0.18);
   --accent: #0a84ff;
   --accent-strong: #409cff;
+  --accent-soft: rgba(10, 132, 255, 0.14);
   --accent-2: #0a84ff;
   --danger: #ff453a;
   --warning: #ffd60a;
   --success: #30d158;
+  --success-soft: rgba(48, 209, 88, 0.18);
   --button-primary-fg: #ffffff;
   --button-secondary-bg: #1c1c1e;
-  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.5);
-  --shadow-raised: 0 4px 14px rgba(0, 0, 0, 0.6);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.5), 0 4px 16px rgba(0, 0, 0, 0.35);
+  --shadow-raised: 0 6px 24px rgba(0, 0, 0, 0.6);
+}
+
+:root[data-theme="dark"] .page-wash {
+  background:
+    radial-gradient(60% 40% at 85% -10%, rgba(10, 132, 255, 0.10), transparent 70%),
+    radial-gradient(50% 40% at -10% 10%, rgba(94, 92, 230, 0.06), transparent 70%);
+}
+
+:root[data-theme="dark"] .metric-card {
+  background:
+    linear-gradient(180deg, rgba(10, 132, 255, 0.06), transparent 40%),
+    var(--panel);
 }
 
 :root[data-theme="dark"] .repo-meter {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,22 +2,25 @@
 
 :root {
   color-scheme: light;
-  --background: #f5efe6;
-  --foreground: #1f2733;
-  --panel: rgba(255, 251, 246, 0.94);
-  --panel-strong: rgba(255, 253, 249, 0.98);
-  --panel-soft: rgba(244, 235, 224, 0.9);
-  --muted: #66707d;
-  --line: rgba(78, 89, 106, 0.14);
-  --line-strong: rgba(78, 89, 106, 0.22);
-  --accent: #6e84ad;
-  --accent-strong: #556b92;
-  --accent-2: #d4a06a;
-  --danger: #ba6c67;
-  --warning: #c89a5e;
-  --success: #668f73;
-  --button-primary-fg: #fffaf4;
-  --button-secondary-bg: rgba(244, 235, 224, 0.92);
+  --background: #fbfbfd;
+  --foreground: #1d1d1f;
+  --panel: #ffffff;
+  --panel-strong: #ffffff;
+  --panel-soft: #f5f5f7;
+  --muted: #6e6e73;
+  --muted-strong: #424245;
+  --line: rgba(0, 0, 0, 0.08);
+  --line-strong: rgba(0, 0, 0, 0.14);
+  --accent: #0071e3;
+  --accent-strong: #0077ed;
+  --accent-2: #0071e3;
+  --danger: #e0404a;
+  --warning: #c48a12;
+  --success: #1f8a3a;
+  --button-primary-fg: #ffffff;
+  --button-secondary-bg: #f5f5f7;
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-raised: 0 4px 14px rgba(0, 0, 0, 0.06);
 }
 
 @theme inline {
@@ -42,13 +45,12 @@ html {
 
 body {
   min-height: 100vh;
-  background:
-    radial-gradient(circle at top left, rgba(255, 255, 255, 0.95), transparent 34%),
-    radial-gradient(circle at bottom right, rgba(212, 160, 106, 0.14), transparent 30%),
-    linear-gradient(180deg, #f8f3ec 0%, #f1e8dd 100%);
+  background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-manrope), sans-serif;
-  letter-spacing: -0.01em;
+  font-family: var(--font-manrope), -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
+  letter-spacing: -0.011em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 a {
@@ -57,7 +59,7 @@ a {
 }
 
 ::selection {
-  background: rgba(110, 132, 173, 0.2);
+  background: rgba(0, 113, 227, 0.18);
   color: var(--foreground);
 }
 
@@ -66,15 +68,12 @@ a {
   overflow-x: clip;
 }
 
+/* Decorative wash — intentionally blank in the minimal theme. */
 .page-wash {
-  pointer-events: none;
-  position: fixed;
-  inset: 0;
-  background:
-    radial-gradient(circle at 8% 12%, rgba(255, 255, 255, 0.7), transparent 26%),
-    radial-gradient(circle at 92% 18%, rgba(110, 132, 173, 0.12), transparent 24%),
-    radial-gradient(circle at 72% 92%, rgba(212, 160, 106, 0.12), transparent 26%);
+  display: none;
 }
+
+/* ---------- Surfaces ---------- */
 
 .top-panel,
 .dashboard-shell,
@@ -85,58 +84,75 @@ a {
 .status-note {
   position: relative;
   border: 1px solid var(--line);
-  background: linear-gradient(180deg, var(--panel-strong), var(--panel));
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.8),
-    0 18px 48px rgba(94, 79, 60, 0.08);
+  background: var(--panel);
+  box-shadow: var(--shadow-card);
 }
 
 .top-panel,
 .dashboard-shell,
-.sidebar-panel,
-.story-panel {
-  border-radius: 2rem;
+.story-panel,
+.sidebar-panel {
+  border-radius: 18px;
 }
 
 .top-panel {
   display: grid;
-  gap: 1.25rem;
-  padding: 1.2rem;
+  gap: 1.5rem;
+  padding: 1.75rem;
 }
 
 @media (min-width: 1024px) {
   .top-panel {
-    grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.7fr);
+    grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.6fr);
     align-items: start;
-    padding: 2rem;
+    padding: 2.25rem 2.5rem;
+    gap: 2.5rem;
   }
 }
 
 .top-panel-copy {
   display: flex;
   flex-direction: column;
-  gap: 0.8rem;
+  gap: 1.25rem;
 }
 
-.page-title,
-.panel-heading {
-  font-family: var(--font-newsreader), serif;
-  letter-spacing: -0.04em;
-  line-height: 0.92;
-}
+/* ---------- Typography ---------- */
 
 .page-title {
-  max-width: 12ch;
-  font-size: clamp(2.5rem, 5vw, 4.5rem);
-  font-weight: 500;
+  max-width: 18ch;
+  font-family: inherit;
+  font-size: clamp(2.25rem, 5vw, 3.75rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.04;
+  color: var(--foreground);
 }
 
 .page-description {
-  max-width: 34rem;
+  max-width: 36rem;
   color: var(--muted);
-  font-size: 0.98rem;
-  line-height: 1.65;
+  font-size: 1.0625rem;
+  line-height: 1.5;
 }
+
+.panel-heading {
+  font-family: inherit;
+  font-size: clamp(1.35rem, 2vw, 1.625rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  color: var(--foreground);
+}
+
+.dashboard-title {
+  font-family: inherit;
+  font-size: clamp(2rem, 3.2vw, 2.75rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+}
+
+/* ---------- Labels / chips ---------- */
 
 .eyebrow,
 .dashboard-pill,
@@ -146,50 +162,97 @@ a {
 .legend-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.4rem;
   width: fit-content;
-  border-radius: 9999px;
-  font-size: 0.74rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+  font-weight: 500;
 }
 
 .eyebrow {
-  border: 1px solid rgba(110, 132, 173, 0.18);
-  background: rgba(110, 132, 173, 0.08);
-  color: var(--accent-strong);
-  padding: 0.45rem 0.78rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .eyebrow-subtle {
-  border-color: rgba(78, 89, 106, 0.14);
-  background: rgba(255, 255, 255, 0.5);
   color: var(--muted);
 }
+
+.panel-label,
+.metric-label {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.panel-label + .panel-heading {
+  margin-top: 0.35rem;
+}
+
+.dashboard-pill,
+.filter-chip,
+.repo-visibility,
+.legend-pill {
+  border-radius: 9999px;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  color: var(--muted-strong);
+  padding: 0.35rem 0.7rem;
+  font-size: 0.8125rem;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.repo-rank {
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  color: var(--muted);
+  padding: 0.15rem 0.45rem;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.repo-visibility {
+  color: var(--muted);
+}
+
+/* ---------- Hero meta ---------- */
 
 .top-panel-meta {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  border-radius: 1.6rem;
+  gap: 1rem;
+  border-radius: 14px;
   border: 1px solid var(--line);
-  background: rgba(247, 241, 234, 0.84);
-  padding: 1.1rem;
+  background: var(--panel-soft);
+  padding: 1.25rem;
 }
 
 .meta-stack {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 0;
 }
 
 .meta-row {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  padding-bottom: 0.65rem;
-  border-bottom: 1px solid rgba(78, 89, 106, 0.1);
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.meta-row:first-child {
+  padding-top: 0;
 }
 
 .meta-row:last-child {
@@ -199,38 +262,39 @@ a {
 
 .hero-meta-label {
   color: var(--muted);
-  font-size: 0.84rem;
+  font-size: 0.8125rem;
 }
 
 .hero-meta-value {
   text-align: right;
-  font-size: 0.92rem;
-  font-weight: 650;
+  font-size: 0.875rem;
+  font-weight: 500;
   color: var(--foreground);
 }
 
 .hero-note {
   color: var(--muted);
-  font-size: 0.9rem;
-  line-height: 1.6;
+  font-size: 0.8125rem;
+  line-height: 1.5;
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.5rem;
 }
+
+/* ---------- Social preview (kept for other pages) ---------- */
 
 .social-preview-panel {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  border-radius: 1.6rem;
-  border: 1px solid rgba(110, 132, 173, 0.12);
-  background:
-    radial-gradient(circle at top right, rgba(110, 132, 173, 0.12), transparent 44%),
-    linear-gradient(180deg, rgba(247, 241, 234, 0.94), rgba(243, 235, 224, 0.9));
-  padding: 1.1rem;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
 }
 
 .social-preview-stack {
@@ -242,45 +306,45 @@ a {
 .social-preview-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
   width: fit-content;
   border-radius: 9999px;
-  border: 1px solid rgba(110, 132, 173, 0.16);
-  background: rgba(255, 255, 255, 0.6);
-  color: var(--accent-strong);
-  padding: 0.55rem 0.78rem;
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  color: var(--muted-strong);
+  padding: 0.35rem 0.7rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .social-preview-kicker {
   color: var(--muted);
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .social-preview-title {
-  max-width: 13ch;
-  font-family: var(--font-newsreader), serif;
-  font-size: clamp(2rem, 3.8vw, 3rem);
-  line-height: 0.96;
-  letter-spacing: -0.04em;
+  font-family: inherit;
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  font-weight: 600;
 }
 
 .social-preview-copy {
   max-width: 28rem;
   color: var(--muted);
-  font-size: 0.98rem;
-  line-height: 1.65;
+  font-size: 0.9375rem;
+  line-height: 1.55;
 }
 
 .social-preview-grid {
   display: grid;
-  gap: 0.85rem;
+  gap: 0.75rem;
 }
 
 .social-preview-card {
@@ -288,37 +352,36 @@ a {
   grid-template-columns: auto 1fr;
   gap: 0.8rem;
   align-items: start;
-  border-radius: 1.35rem;
-  border: 1px solid rgba(78, 89, 106, 0.1);
-  background: rgba(255, 255, 255, 0.58);
-  padding: 0.95rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  padding: 0.9rem 1rem;
 }
 
 .social-preview-card svg {
   margin-top: 0.15rem;
-  color: var(--accent-strong);
+  color: var(--accent);
 }
 
 .social-preview-label {
-  font-size: 0.95rem;
-  font-weight: 700;
+  font-size: 0.9375rem;
+  font-weight: 600;
   color: var(--foreground);
 }
 
 .social-preview-detail {
   margin-top: 0.2rem;
   color: var(--muted);
-  font-size: 0.9rem;
-  line-height: 1.55;
+  font-size: 0.875rem;
+  line-height: 1.5;
 }
+
+/* ---------- Dashboard / cards ---------- */
 
 .dashboard-shell,
-.sidebar-panel {
-  padding: 1.2rem;
-}
-
+.sidebar-panel,
 .story-panel {
-  padding: 1.2rem;
+  padding: 1.5rem;
 }
 
 @media (min-width: 768px) {
@@ -326,16 +389,16 @@ a {
   .sidebar-panel,
   .story-panel,
   .top-panel {
-    padding: 1.45rem;
+    padding: 1.75rem;
   }
 }
 
 .dashboard-head {
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
+  gap: 1rem;
   border-bottom: 1px solid var(--line);
-  padding-bottom: 1rem;
+  padding-bottom: 1.25rem;
 }
 
 @media (min-width: 1200px) {
@@ -344,44 +407,6 @@ a {
     justify-content: space-between;
     align-items: end;
   }
-}
-
-.dashboard-title {
-  font-family: var(--font-manrope), sans-serif;
-  font-size: clamp(2.7rem, 4vw, 4rem);
-  font-weight: 750;
-  letter-spacing: -0.05em;
-  line-height: 0.94;
-}
-
-.panel-heading {
-  font-size: clamp(1.8rem, 2.6vw, 2.35rem);
-  font-weight: 500;
-  line-height: 0.98;
-}
-
-.panel-label,
-.metric-label {
-  color: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-}
-
-.panel-label + .panel-heading {
-  margin-top: 0.45rem;
-}
-
-.dashboard-pill,
-.filter-chip,
-.repo-visibility,
-.repo-rank,
-.legend-pill {
-  border: 1px solid rgba(78, 89, 106, 0.12);
-  background: rgba(247, 241, 234, 0.9);
-  color: var(--muted);
-  padding: 0.48rem 0.78rem;
 }
 
 .control-stack {
@@ -394,36 +419,39 @@ a {
 .filter-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
+  gap: 0.4rem;
 }
 
 .metric-card,
 .onboarding-card {
-  border-radius: 1.5rem;
-  padding: 1rem;
+  border-radius: 14px;
+  padding: 1.25rem;
 }
 
 .metric-card {
   display: flex;
   flex-direction: column;
-  gap: 0.7rem;
+  gap: 0.5rem;
   min-height: 100%;
 }
 
 .metric-value {
-  font-family: var(--font-manrope), sans-serif;
-  font-size: clamp(2rem, 3vw, 3.2rem);
-  font-weight: 700;
-  letter-spacing: -0.06em;
-  line-height: 0.94;
+  font-family: inherit;
+  font-size: clamp(1.75rem, 2.6vw, 2.25rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
 
 .metric-detail {
-  max-width: 30ch;
+  max-width: 32ch;
   color: var(--muted);
-  font-size: 0.92rem;
-  line-height: 1.55;
+  font-size: 0.875rem;
+  line-height: 1.5;
 }
+
+/* ---------- Chart area ---------- */
 
 .chart-stat-row {
   display: grid;
@@ -437,49 +465,48 @@ a {
 }
 
 .chart-stat-card {
-  border-radius: 1.35rem;
+  border-radius: 12px;
   border: 1px solid var(--line);
-  background: rgba(247, 241, 234, 0.72);
-  padding: 0.95rem 1rem;
+  background: var(--panel-soft);
+  padding: 1rem;
 }
 
 .chart-stat-value {
-  margin-top: 0.45rem;
-  font-family: var(--font-manrope), sans-serif;
-  font-size: clamp(1.85rem, 2.6vw, 2.4rem);
-  font-weight: 700;
-  letter-spacing: -0.05em;
+  margin-top: 0.4rem;
+  font-family: inherit;
+  font-size: clamp(1.5rem, 2.2vw, 1.875rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
 }
 
 .chart-stat-detail,
 .chart-intro {
   max-width: 58ch;
   color: var(--muted);
-  font-size: 0.92rem;
-  line-height: 1.6;
+  font-size: 0.875rem;
+  line-height: 1.55;
 }
 
 .chart-stat-detail {
-  margin-top: 0.45rem;
+  margin-top: 0.4rem;
 }
 
 .chart-legend {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
 }
 
 .legend-pill {
-  font-size: 0.72rem;
-  border: 1px solid rgba(78, 89, 106, 0.1);
-  background: rgba(250, 245, 238, 0.72);
-  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  padding: 0.3rem 0.65rem;
 }
 
 .legend-swatch {
-  height: 0.6rem;
-  width: 0.6rem;
+  height: 0.5rem;
+  width: 0.5rem;
   border-radius: 9999px;
 }
 
@@ -488,24 +515,20 @@ a {
 }
 
 .legend-swatch-deletions {
-  background: var(--accent-2);
+  background: #86868b;
 }
 
 .bar-chart-shell {
   overflow: hidden;
-  border-radius: 1.6rem;
-  border: 1px solid rgba(78, 89, 106, 0.1);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(248, 242, 234, 0.88));
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
   padding: 0.85rem 0.7rem 0.7rem;
 }
 
 .chart-bar {
   cursor: pointer;
-  transition:
-    opacity 160ms ease,
-    transform 160ms ease,
-    filter 160ms ease;
+  transition: opacity 160ms ease, filter 160ms ease;
   transform-box: fill-box;
   transform-origin: center bottom;
 }
@@ -513,84 +536,80 @@ a {
 .chart-bar:hover,
 .chart-bar-group:focus-visible .chart-bar,
 .chart-bar-group:hover .chart-bar {
-  opacity: 0.9;
-  filter: brightness(1.05) saturate(1.02);
-  transform: translateY(-2px);
+  opacity: 0.82;
   outline: none;
 }
 
 .chart-axis-caption {
-  fill: rgba(91, 99, 111, 0.82);
+  fill: var(--muted);
   font-family: var(--font-manrope), sans-serif;
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .chart-overflow-cap {
-  stroke: rgba(31, 39, 51, 0.58);
+  stroke: var(--muted-strong);
   stroke-linecap: round;
   stroke-width: 2.5;
 }
+
+/* ---------- Repo list ---------- */
 
 .repo-list {
   margin-top: 1.1rem;
   display: flex;
   max-height: 44rem;
   flex-direction: column;
-  gap: 0.8rem;
+  gap: 0.6rem;
   overflow-y: auto;
   padding-right: 0.2rem;
 }
 
 .repo-card,
 .scope-item {
-  border-radius: 1.4rem;
-  border: 1px solid rgba(78, 89, 106, 0.1);
-  background: rgba(247, 241, 234, 0.72);
-  padding: 0.95rem;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  padding: 1rem;
+  transition: border-color 160ms ease, background-color 160ms ease;
 }
 
-.repo-rank {
-  min-width: 2.3rem;
-  justify-content: center;
-  padding: 0.35rem 0.55rem;
-}
-
-.repo-visibility {
-  color: var(--accent-strong);
+.repo-card:hover {
+  border-color: var(--line-strong);
+  background: var(--panel-soft);
 }
 
 .repo-meter {
-  height: 0.55rem;
+  height: 6px;
   overflow: hidden;
   border-radius: 9999px;
-  background: rgba(78, 89, 106, 0.08);
+  background: rgba(0, 0, 0, 0.06);
 }
 
 .repo-meter-fill {
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  background: var(--accent);
 }
 
 .sidebar-panel {
-  background: linear-gradient(180deg, rgba(255, 252, 248, 0.98), rgba(249, 242, 235, 0.94));
+  background: var(--panel);
 }
 
 .scope-summary {
-  margin-top: 0.8rem;
+  margin-top: 0.75rem;
   color: var(--muted);
-  font-size: 0.92rem;
-  line-height: 1.55;
+  font-size: 0.875rem;
+  line-height: 1.5;
 }
 
 .scope-list {
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .scope-item-head {
@@ -601,68 +620,71 @@ a {
 }
 
 .scope-item-title {
-  font-size: 0.96rem;
-  font-weight: 700;
+  font-size: 0.9375rem;
+  font-weight: 600;
   color: var(--foreground);
 }
 
 .scope-item-meta,
 .scope-copy {
   color: var(--muted);
-  font-size: 0.88rem;
-  line-height: 1.55;
+  font-size: 0.8125rem;
+  line-height: 1.5;
 }
 
 .scope-copy {
-  margin-top: 0.55rem;
+  margin-top: 0.45rem;
   word-break: break-word;
 }
+
+/* ---------- Misc ---------- */
 
 .trust-item {
   display: flex;
   align-items: flex-start;
-  gap: 0.8rem;
+  gap: 0.75rem;
 }
 
 .trust-dot {
   margin-top: 0.55rem;
-  height: 0.55rem;
-  width: 0.55rem;
+  height: 6px;
+  width: 6px;
   flex-shrink: 0;
   border-radius: 9999px;
-  background: linear-gradient(180deg, var(--accent-2), var(--accent-strong));
-  box-shadow: 0 0 0 4px rgba(110, 132, 173, 0.12);
+  background: var(--accent);
 }
 
 .empty-shell {
   display: flex;
   flex-direction: column;
-  gap: 1.6rem;
+  gap: 1.5rem;
 }
 
 .status-note {
-  border-radius: 1.4rem;
+  border-radius: 12px;
   padding: 0.9rem 1rem;
 }
 
 .status-note-neutral {
-  border-color: rgba(78, 89, 106, 0.14);
+  border-color: var(--line);
 }
 
 .status-note-active {
-  border-color: rgba(110, 132, 173, 0.18);
-  background: linear-gradient(180deg, rgba(110, 132, 173, 0.14), rgba(255, 251, 246, 0.92));
+  border-color: rgba(0, 113, 227, 0.22);
+  background: rgba(0, 113, 227, 0.04);
 }
 
 .status-note-success {
-  border-color: rgba(102, 143, 115, 0.2);
-  background: linear-gradient(180deg, rgba(102, 143, 115, 0.12), rgba(255, 251, 246, 0.92));
+  border-color: rgba(31, 138, 58, 0.22);
+  background: rgba(31, 138, 58, 0.04);
 }
 
 .status-note-danger {
-  border-color: rgba(186, 108, 103, 0.18);
-  background: linear-gradient(180deg, rgba(186, 108, 103, 0.12), rgba(255, 251, 246, 0.92));
+  border-color: rgba(224, 64, 74, 0.22);
+  background: rgba(224, 64, 74, 0.04);
 }
+
+/* ---------- Buttons ---------- */
 
 .button-primary,
 .button-secondary,
@@ -670,113 +692,101 @@ a {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  border-radius: 9999px;
-  font-size: 0.92rem;
-  font-weight: 700;
+  gap: 0.4rem;
+  border-radius: 980px;
+  font-size: 0.9375rem;
+  font-weight: 500;
   line-height: 1;
-  transition:
-    border-color 180ms ease,
-    background-color 180ms ease,
-    color 180ms ease,
-    box-shadow 180ms ease,
-    transform 180ms ease;
+  letter-spacing: -0.005em;
+  transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease, opacity 160ms ease;
 }
 
 .button-primary,
 .button-secondary {
-  min-height: 3rem;
-  padding: 0.8rem 1.1rem;
+  min-height: 2.5rem;
+  padding: 0.6rem 1.1rem;
 }
 
 .button-compact {
-  min-height: 2.4rem;
-  padding: 0.65rem 0.95rem;
-  font-size: 0.84rem;
+  min-height: 2rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.8125rem;
 }
 
 .button-primary:disabled,
 .button-secondary:disabled {
   cursor: wait;
-  opacity: 0.72;
-  transform: none;
-  box-shadow: none;
+  opacity: 0.55;
 }
 
 .button-primary {
-  border: 1px solid rgba(85, 107, 146, 0.3);
-  background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+  border: 1px solid var(--accent);
+  background: var(--accent);
   color: var(--button-primary-fg);
-  box-shadow: 0 10px 24px rgba(85, 107, 146, 0.18);
 }
 
 .button-primary:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 14px 28px rgba(85, 107, 146, 0.2);
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
 }
 
 .button-secondary {
-  border: 1px solid rgba(78, 89, 106, 0.12);
-  background: var(--button-secondary-bg);
+  border: 1px solid var(--line-strong);
+  background: transparent;
   color: var(--foreground);
 }
 
 .button-secondary:hover {
-  transform: translateY(-1px);
-  border-color: rgba(85, 107, 146, 0.18);
-  background: rgba(239, 231, 220, 0.98);
+  background: var(--panel-soft);
+  border-color: var(--line-strong);
 }
 
 .toggle-pill {
-  min-height: 2.5rem;
-  border: 1px solid rgba(78, 89, 106, 0.12);
-  background: rgba(255, 255, 255, 0.54);
-  color: var(--muted);
-  padding: 0.62rem 0.92rem;
+  min-height: 2.25rem;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted-strong);
+  padding: 0.45rem 0.85rem;
+  font-size: 0.875rem;
 }
 
 .toggle-pill:hover {
-  transform: translateY(-1px);
-  border-color: rgba(85, 107, 146, 0.18);
   color: var(--foreground);
+  background: var(--panel-soft);
 }
 
 .toggle-pill-active {
-  border-color: rgba(85, 107, 146, 0.22);
-  background: rgba(110, 132, 173, 0.14);
-  color: var(--accent-strong);
-  box-shadow: inset 0 0 0 1px rgba(110, 132, 173, 0.08);
+  border-color: var(--foreground);
+  background: var(--foreground);
+  color: var(--background);
 }
 
 .button-primary:focus-visible,
 .button-secondary:focus-visible,
 .toggle-pill:focus-visible {
   outline: none;
-  box-shadow:
-    0 0 0 3px rgba(245, 239, 230, 0.96),
-    0 0 0 5px rgba(110, 132, 173, 0.24);
+  box-shadow: 0 0 0 3px var(--background), 0 0 0 5px rgba(0, 113, 227, 0.5);
 }
 
 @media (max-width: 767px) {
   .top-panel,
   .dashboard-shell,
   .story-panel,
-  .sidebar-panel,
-  .metric-card,
-  .onboarding-card {
-    border-radius: 1.5rem;
+  .sidebar-panel {
+    border-radius: 14px;
   }
 
-  .page-title {
-    max-width: 10ch;
+  .metric-card,
+  .onboarding-card {
+    border-radius: 12px;
   }
 
   .dashboard-title {
-    font-size: clamp(2.25rem, 10vw, 3rem);
+    font-size: clamp(1.75rem, 8vw, 2.25rem);
   }
 
   .panel-heading {
-    font-size: clamp(1.55rem, 8vw, 2rem);
+    font-size: clamp(1.25rem, 6vw, 1.5rem);
   }
 
   .bar-chart-shell {
@@ -787,10 +797,6 @@ a {
     flex-direction: column;
     align-items: stretch;
   }
-
-  .social-preview-title {
-    max-width: 11ch;
-  }
 }
 
 /* ============================================================
@@ -800,356 +806,124 @@ a {
         has not yet run (or JS is disabled). Blocked by [data-theme="light"].
      2. [data-theme="dark"] — JS-controlled; set immediately by the
         anti-flash inline script in layout.tsx, and toggled by ThemeToggle.
-   All element-level overrides (gradients, borders, etc.) live under
-   [data-theme="dark"] so the toggle responds instantly without a reload.
    ============================================================ */
 
-/* --- CSS variables: system dark fallback (pre-JS) --- */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
     color-scheme: dark;
-    --background: #1a1714;
-    --foreground: #e8e0d5;
-    --panel: rgba(30, 26, 22, 0.94);
-    --panel-strong: rgba(36, 31, 26, 0.98);
-    --panel-soft: rgba(40, 34, 28, 0.90);
-    --muted: #8c8078;
-    --line: rgba(200, 185, 165, 0.12);
-    --line-strong: rgba(200, 185, 165, 0.20);
-    --accent: #8fa3c8;
-    --accent-strong: #7d94ba;
-    --accent-2: #c89a6a;
-    --danger: #c47c78;
-    --warning: #c89a5e;
-    --success: #7aa888;
-    --button-primary-fg: #f0e8de;
-    --button-secondary-bg: rgba(44, 38, 32, 0.92);
-  }
-
-  :root:not([data-theme="light"]) body {
-    background:
-      radial-gradient(circle at top left, rgba(60, 50, 40, 0.6), transparent 34%),
-      radial-gradient(circle at bottom right, rgba(160, 100, 50, 0.10), transparent 30%),
-      linear-gradient(180deg, #1a1714 0%, #15120f 100%);
-  }
-
-  :root:not([data-theme="light"]) .page-wash {
-    background:
-      radial-gradient(circle at 8% 12%, rgba(60, 50, 40, 0.40), transparent 26%),
-      radial-gradient(circle at 92% 18%, rgba(110, 132, 173, 0.08), transparent 24%),
-      radial-gradient(circle at 72% 92%, rgba(160, 100, 50, 0.08), transparent 26%);
-  }
-
-  :root:not([data-theme="light"]) .top-panel,
-  :root:not([data-theme="light"]) .dashboard-shell,
-  :root:not([data-theme="light"]) .story-panel,
-  :root:not([data-theme="light"]) .sidebar-panel,
-  :root:not([data-theme="light"]) .metric-card,
-  :root:not([data-theme="light"]) .onboarding-card,
-  :root:not([data-theme="light"]) .status-note {
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.06),
-      0 18px 48px rgba(0, 0, 0, 0.30);
-  }
-
-  :root:not([data-theme="light"]) .top-panel-meta {
-    background: rgba(26, 22, 18, 0.84);
-  }
-
-  :root:not([data-theme="light"]) .social-preview-panel {
-    border-color: rgba(143, 163, 200, 0.18);
-    background:
-      radial-gradient(circle at top right, rgba(143, 163, 200, 0.12), transparent 44%),
-      linear-gradient(180deg, rgba(34, 29, 24, 0.96), rgba(28, 24, 20, 0.94));
-  }
-
-  :root:not([data-theme="light"]) .social-preview-badge,
-  :root:not([data-theme="light"]) .social-preview-card {
-    border-color: rgba(200, 185, 165, 0.12);
-    background: rgba(24, 20, 16, 0.76);
-  }
-
-  :root:not([data-theme="light"]) .meta-row {
-    border-bottom-color: rgba(200, 185, 165, 0.10);
-  }
-
-  :root:not([data-theme="light"]) .eyebrow-subtle {
-    border-color: rgba(200, 185, 165, 0.14);
-    background: rgba(36, 31, 26, 0.5);
-  }
-
-  :root:not([data-theme="light"]) .eyebrow {
-    border-color: rgba(143, 163, 200, 0.22);
-    background: rgba(143, 163, 200, 0.12);
-  }
-
-  :root:not([data-theme="light"]) .dashboard-pill,
-  :root:not([data-theme="light"]) .filter-chip,
-  :root:not([data-theme="light"]) .repo-visibility,
-  :root:not([data-theme="light"]) .repo-rank,
-  :root:not([data-theme="light"]) .legend-pill {
-    border-color: rgba(200, 185, 165, 0.12);
-    background: rgba(26, 22, 18, 0.90);
-  }
-
-  :root:not([data-theme="light"]) .bar-chart-shell {
-    border-color: rgba(200, 185, 165, 0.10);
-    background:
-      linear-gradient(to top, rgba(110, 132, 173, 0.08) 1px, transparent 1px),
-      linear-gradient(180deg, rgba(30, 26, 22, 0.92), rgba(24, 20, 16, 0.92));
-  }
-
-  :root:not([data-theme="light"]) .bar-chart-shell line {
-    stroke: rgba(200, 185, 165, 0.14);
-  }
-
-  :root:not([data-theme="light"]) .bar-chart-shell text {
-    fill: rgba(180, 165, 145, 0.85);
-  }
-
-  :root:not([data-theme="light"]) .chart-stat-card {
-    background: rgba(26, 22, 18, 0.72);
-  }
-
-  :root:not([data-theme="light"]) .repo-card,
-  :root:not([data-theme="light"]) .scope-item {
-    border-color: rgba(200, 185, 165, 0.10);
-    background: rgba(26, 22, 18, 0.72);
+    --background: #000000;
+    --foreground: #f5f5f7;
+    --panel: #1c1c1e;
+    --panel-strong: #1c1c1e;
+    --panel-soft: #161618;
+    --muted: #98989d;
+    --muted-strong: #c7c7cc;
+    --line: rgba(255, 255, 255, 0.1);
+    --line-strong: rgba(255, 255, 255, 0.18);
+    --accent: #0a84ff;
+    --accent-strong: #409cff;
+    --accent-2: #0a84ff;
+    --danger: #ff453a;
+    --warning: #ffd60a;
+    --success: #30d158;
+    --button-primary-fg: #ffffff;
+    --button-secondary-bg: #1c1c1e;
+    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.5);
+    --shadow-raised: 0 4px 14px rgba(0, 0, 0, 0.6);
   }
 
   :root:not([data-theme="light"]) .repo-meter {
-    background: rgba(200, 185, 165, 0.10);
-  }
-
-  :root:not([data-theme="light"]) .sidebar-panel {
-    background: linear-gradient(180deg, rgba(34, 29, 24, 0.98), rgba(28, 23, 18, 0.94));
-  }
-
-  :root:not([data-theme="light"]) .status-note-active {
-    border-color: rgba(110, 132, 173, 0.22);
-    background: linear-gradient(180deg, rgba(110, 132, 173, 0.16), rgba(30, 26, 22, 0.92));
-  }
-
-  :root:not([data-theme="light"]) .status-note-success {
-    border-color: rgba(102, 143, 115, 0.24);
-    background: linear-gradient(180deg, rgba(102, 143, 115, 0.14), rgba(30, 26, 22, 0.92));
-  }
-
-  :root:not([data-theme="light"]) .status-note-danger {
-    border-color: rgba(186, 108, 103, 0.22);
-    background: linear-gradient(180deg, rgba(186, 108, 103, 0.14), rgba(30, 26, 22, 0.92));
-  }
-
-  :root:not([data-theme="light"]) .button-secondary:hover {
-    border-color: rgba(143, 163, 200, 0.22);
-    background: rgba(52, 44, 36, 0.98);
-  }
-
-  :root:not([data-theme="light"]) .toggle-pill {
-    border-color: rgba(200, 185, 165, 0.12);
-    background: rgba(36, 31, 26, 0.54);
+    background: rgba(255, 255, 255, 0.08);
   }
 
   :root:not([data-theme="light"]) .toggle-pill-active {
-    border-color: rgba(143, 163, 200, 0.30);
-    background: rgba(143, 163, 200, 0.18);
-    color: var(--accent-strong);
-    box-shadow: inset 0 0 0 1px rgba(143, 163, 200, 0.10);
+    border-color: var(--foreground);
+    background: var(--foreground);
+    color: #000000;
   }
 
-  :root:not([data-theme="light"]) .button-primary:focus-visible,
-  :root:not([data-theme="light"]) .button-secondary:focus-visible,
-  :root:not([data-theme="light"]) .toggle-pill:focus-visible {
-    box-shadow:
-      0 0 0 3px rgba(26, 22, 18, 0.96),
-      0 0 0 5px rgba(143, 163, 200, 0.40);
+  :root:not([data-theme="light"]) .legend-swatch-deletions {
+    background: #8e8e93;
   }
 
-  :root:not([data-theme="light"]) .bg-white\/70 {
-    background-color: rgba(30, 26, 22, 0.70) !important;
+  :root:not([data-theme="light"]) .status-note-active {
+    background: rgba(10, 132, 255, 0.08);
   }
 
-  :root:not([data-theme="light"]) .bg-white\/65 {
-    background-color: rgba(30, 26, 22, 0.65) !important;
+  :root:not([data-theme="light"]) .status-note-success {
+    background: rgba(48, 209, 88, 0.08);
+  }
+
+  :root:not([data-theme="light"]) .status-note-danger {
+    background: rgba(255, 69, 58, 0.08);
+  }
+
+  :root:not([data-theme="light"]) .bg-white\/70,
+  :root:not([data-theme="light"]) .bg-white\/65,
+  :root:not([data-theme="light"]) .bg-white\/60 {
+    background-color: var(--panel-soft) !important;
   }
 
   :root:not([data-theme="light"]) .bg-white {
-    background-color: #1e1a16 !important;
+    background-color: var(--panel) !important;
   }
 }
 
-/* --- CSS variables: explicit dark (JS toggle) --- */
 :root[data-theme="dark"] {
   color-scheme: dark;
-  --background: #1a1714;
-  --foreground: #e8e0d5;
-  --panel: rgba(30, 26, 22, 0.94);
-  --panel-strong: rgba(36, 31, 26, 0.98);
-  --panel-soft: rgba(40, 34, 28, 0.90);
-  --muted: #8c8078;
-  --line: rgba(200, 185, 165, 0.12);
-  --line-strong: rgba(200, 185, 165, 0.20);
-  --accent: #8fa3c8;
-  --accent-strong: #7d94ba;
-  --accent-2: #c89a6a;
-  --danger: #c47c78;
-  --warning: #c89a5e;
-  --success: #7aa888;
-  --button-primary-fg: #f0e8de;
-  --button-secondary-bg: rgba(44, 38, 32, 0.92);
-}
-
-/* --- Element overrides: [data-theme="dark"] only (instant toggle response) --- */
-
-:root[data-theme="dark"] body {
-  background:
-    radial-gradient(circle at top left, rgba(60, 50, 40, 0.6), transparent 34%),
-    radial-gradient(circle at bottom right, rgba(160, 100, 50, 0.10), transparent 30%),
-    linear-gradient(180deg, #1a1714 0%, #15120f 100%);
-}
-
-:root[data-theme="dark"] .page-wash {
-  background:
-    radial-gradient(circle at 8% 12%, rgba(60, 50, 40, 0.40), transparent 26%),
-    radial-gradient(circle at 92% 18%, rgba(110, 132, 173, 0.08), transparent 24%),
-    radial-gradient(circle at 72% 92%, rgba(160, 100, 50, 0.08), transparent 26%);
-}
-
-:root[data-theme="dark"] .top-panel,
-:root[data-theme="dark"] .dashboard-shell,
-:root[data-theme="dark"] .story-panel,
-:root[data-theme="dark"] .sidebar-panel,
-:root[data-theme="dark"] .metric-card,
-:root[data-theme="dark"] .onboarding-card,
-:root[data-theme="dark"] .status-note {
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    0 18px 48px rgba(0, 0, 0, 0.30);
-}
-
-:root[data-theme="dark"] .top-panel-meta {
-  background: rgba(26, 22, 18, 0.84);
-}
-
-:root[data-theme="dark"] .social-preview-panel {
-  border-color: rgba(143, 163, 200, 0.18);
-  background:
-    radial-gradient(circle at top right, rgba(143, 163, 200, 0.12), transparent 44%),
-    linear-gradient(180deg, rgba(34, 29, 24, 0.96), rgba(28, 24, 20, 0.94));
-}
-
-:root[data-theme="dark"] .social-preview-badge,
-:root[data-theme="dark"] .social-preview-card {
-  border-color: rgba(200, 185, 165, 0.12);
-  background: rgba(24, 20, 16, 0.76);
-}
-
-:root[data-theme="dark"] .meta-row {
-  border-bottom-color: rgba(200, 185, 165, 0.10);
-}
-
-:root[data-theme="dark"] .eyebrow-subtle {
-  border-color: rgba(200, 185, 165, 0.14);
-  background: rgba(36, 31, 26, 0.5);
-}
-
-:root[data-theme="dark"] .eyebrow {
-  border-color: rgba(143, 163, 200, 0.22);
-  background: rgba(143, 163, 200, 0.12);
-}
-
-:root[data-theme="dark"] .dashboard-pill,
-:root[data-theme="dark"] .filter-chip,
-:root[data-theme="dark"] .repo-visibility,
-:root[data-theme="dark"] .repo-rank,
-:root[data-theme="dark"] .legend-pill {
-  border-color: rgba(200, 185, 165, 0.12);
-  background: rgba(26, 22, 18, 0.90);
-}
-
-:root[data-theme="dark"] .bar-chart-shell {
-  border-color: rgba(200, 185, 165, 0.10);
-  background:
-    linear-gradient(to top, rgba(110, 132, 173, 0.08) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(30, 26, 22, 0.92), rgba(24, 20, 16, 0.92));
-}
-
-:root[data-theme="dark"] .bar-chart-shell line {
-  stroke: rgba(200, 185, 165, 0.14);
-}
-
-:root[data-theme="dark"] .bar-chart-shell text {
-  fill: rgba(180, 165, 145, 0.85);
-}
-
-:root[data-theme="dark"] .chart-stat-card {
-  background: rgba(26, 22, 18, 0.72);
-}
-
-:root[data-theme="dark"] .repo-card,
-:root[data-theme="dark"] .scope-item {
-  border-color: rgba(200, 185, 165, 0.10);
-  background: rgba(26, 22, 18, 0.72);
+  --background: #000000;
+  --foreground: #f5f5f7;
+  --panel: #1c1c1e;
+  --panel-strong: #1c1c1e;
+  --panel-soft: #161618;
+  --muted: #98989d;
+  --muted-strong: #c7c7cc;
+  --line: rgba(255, 255, 255, 0.1);
+  --line-strong: rgba(255, 255, 255, 0.18);
+  --accent: #0a84ff;
+  --accent-strong: #409cff;
+  --accent-2: #0a84ff;
+  --danger: #ff453a;
+  --warning: #ffd60a;
+  --success: #30d158;
+  --button-primary-fg: #ffffff;
+  --button-secondary-bg: #1c1c1e;
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --shadow-raised: 0 4px 14px rgba(0, 0, 0, 0.6);
 }
 
 :root[data-theme="dark"] .repo-meter {
-  background: rgba(200, 185, 165, 0.10);
+  background: rgba(255, 255, 255, 0.08);
 }
 
-:root[data-theme="dark"] .sidebar-panel {
-  background: linear-gradient(180deg, rgba(34, 29, 24, 0.98), rgba(28, 23, 18, 0.94));
+:root[data-theme="dark"] .toggle-pill-active {
+  border-color: var(--foreground);
+  background: var(--foreground);
+  color: #000000;
+}
+
+:root[data-theme="dark"] .legend-swatch-deletions {
+  background: #8e8e93;
 }
 
 :root[data-theme="dark"] .status-note-active {
-  border-color: rgba(110, 132, 173, 0.22);
-  background: linear-gradient(180deg, rgba(110, 132, 173, 0.16), rgba(30, 26, 22, 0.92));
+  background: rgba(10, 132, 255, 0.08);
 }
 
 :root[data-theme="dark"] .status-note-success {
-  border-color: rgba(102, 143, 115, 0.24);
-  background: linear-gradient(180deg, rgba(102, 143, 115, 0.14), rgba(30, 26, 22, 0.92));
+  background: rgba(48, 209, 88, 0.08);
 }
 
 :root[data-theme="dark"] .status-note-danger {
-  border-color: rgba(186, 108, 103, 0.22);
-  background: linear-gradient(180deg, rgba(186, 108, 103, 0.14), rgba(30, 26, 22, 0.92));
+  background: rgba(255, 69, 58, 0.08);
 }
 
-:root[data-theme="dark"] .button-secondary:hover {
-  border-color: rgba(143, 163, 200, 0.22);
-  background: rgba(52, 44, 36, 0.98);
-}
-
-:root[data-theme="dark"] .toggle-pill {
-  border-color: rgba(200, 185, 165, 0.12);
-  background: rgba(36, 31, 26, 0.54);
-}
-
-/* Must come after .toggle-pill to win on specificity tie */
-:root[data-theme="dark"] .toggle-pill-active {
-  border-color: rgba(143, 163, 200, 0.30);
-  background: rgba(143, 163, 200, 0.18);
-  color: var(--accent-strong);
-  box-shadow: inset 0 0 0 1px rgba(143, 163, 200, 0.10);
-}
-
-:root[data-theme="dark"] .button-primary:focus-visible,
-:root[data-theme="dark"] .button-secondary:focus-visible,
-:root[data-theme="dark"] .toggle-pill:focus-visible {
-  box-shadow:
-    0 0 0 3px rgba(26, 22, 18, 0.96),
-    0 0 0 5px rgba(143, 163, 200, 0.40);
-}
-
-/* Tailwind white utility overrides — social-shell.tsx and page.tsx card surfaces */
-:root[data-theme="dark"] .bg-white\/70 {
-  background-color: rgba(30, 26, 22, 0.70) !important;
-}
-
-:root[data-theme="dark"] .bg-white\/65 {
-  background-color: rgba(30, 26, 22, 0.65) !important;
+:root[data-theme="dark"] .bg-white\/70,
+:root[data-theme="dark"] .bg-white\/65,
+:root[data-theme="dark"] .bg-white\/60 {
+  background-color: var(--panel-soft) !important;
 }
 
 :root[data-theme="dark"] .bg-white {
-  background-color: #1e1a16 !important;
+  background-color: var(--panel) !important;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Manrope, Newsreader } from "next/font/google";
+import { Manrope } from "next/font/google";
 import { TimezoneSync } from "@/components/timezone-sync";
 import "./globals.css";
 
@@ -12,13 +12,6 @@ const manrope = Manrope({
   subsets: ["latin"],
   display: "swap",
 });
-
-const newsreader = Newsreader({
-  variable: "--font-newsreader",
-  subsets: ["latin"],
-  display: "swap",
-});
-
 
 export const metadata: Metadata = {
   title: "Vibe Tracker",
@@ -37,7 +30,7 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: ANTI_FLASH_SCRIPT }} />
       </head>
       <body
-        className={`${manrope.variable} ${newsreader.variable} bg-background text-foreground antialiased selection:bg-accent/20 selection:text-foreground`}
+        className={`${manrope.variable} bg-background text-foreground antialiased selection:bg-accent/20 selection:text-foreground`}
       >
         <TimezoneSync />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -723,18 +723,22 @@ export default async function Home({ searchParams }: HomePageProps) {
       <div className="relative mx-auto flex w-full max-w-[1280px] flex-col gap-4 px-4 py-4 sm:px-6 sm:py-7 lg:px-8 lg:py-8">
         <section className="top-panel">
           <div className="top-panel-copy">
-            <span className="eyebrow">Vibe Tracker</span>
-            <div className="flex flex-wrap items-center gap-2">
-              <Link href="/" className="toggle-pill toggle-pill-active">
-                Dashboard
-              </Link>
-              <Link href="/social" className="toggle-pill">
-                Social
-              </Link>
-              <ThemeToggle />
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-[0.9375rem] font-semibold tracking-tight text-foreground">
+                Vibe Tracker
+              </span>
+              <div className="flex flex-wrap items-center gap-1">
+                <Link href="/" className="toggle-pill toggle-pill-active">
+                  Dashboard
+                </Link>
+                <Link href="/social" className="toggle-pill">
+                  Social
+                </Link>
+                <ThemeToggle />
+              </div>
             </div>
-            <div className="space-y-3">
-              <h1 className="page-title">Everyone is vibe coding, but how much?</h1>
+            <div className="space-y-4">
+              <h1 className="page-title">How much are you actually shipping?</h1>
               <p className="page-description">
                 Track shipped work, recent momentum, and repository impact from your merged pull requests.
               </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -738,6 +738,7 @@ export default async function Home({ searchParams }: HomePageProps) {
               </div>
             </div>
             <div className="space-y-4">
+              <span className="hero-kicker">Shipped-work analytics</span>
               <h1 className="page-title">How much are you actually shipping?</h1>
               <p className="page-description">
                 Track shipped work, recent momentum, and repository impact from your merged pull requests.
@@ -750,7 +751,12 @@ export default async function Home({ searchParams }: HomePageProps) {
               <div className="meta-row">
                 <span className="hero-meta-label">GitHub</span>
                 <span className="hero-meta-value">
-                  {githubState.connected ? "GitHub connected" : "Not connected"}
+                  <span
+                    className={
+                      githubState.connected ? "status-dot status-dot-live" : "status-dot"
+                    }
+                  />
+                  {githubState.connected ? "Connected" : "Not connected"}
                 </span>
               </div>
               <div className="meta-row">


### PR DESCRIPTION
## Summary
- Rewrites `globals.css` with a neutral off-white / near-black palette and a single Apple blue accent; dark mode uses true black + `#1c1c1e` panels
- Drops the Newsreader serif font entirely and flattens glassmorphism panels to hairline-bordered cards with 12–18px radii
- Cleans up the homepage hero: new headline, wordmark replaces the uppercase "Vibe Tracker" chip, nav pushed right
- All existing class names preserved — `/social`, `/privacy`, and `/social/profile/[login]` inherit the new look without code changes

## Test plan
- [ ] Homepage (connected + disconnected states) looks right in light and dark mode
- [ ] `/social` and `/social/profile/[login]` inherit the restyled cards without layout breakage
- [ ] `/privacy` reads cleanly with the new typography
- [ ] Theme toggle still flips instantly
- [ ] Mobile (<768px) renders without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)